### PR TITLE
Fixed incorrect route details header on LTR mode

### DIFF
--- a/app/components/route-details-header/route-details-header.tsx
+++ b/app/components/route-details-header/route-details-header.tsx
@@ -12,7 +12,7 @@ const colorScheme = Appearance.getColorScheme()
 // #region styles
 
 const ROUTE_DETAILS_WRAPPER: ViewStyle = {
-  flexDirection: isRTL ? "row" : "row-reverse",
+  flexDirection: "row",
   justifyContent: "center",
   alignItems: "center",
 }

--- a/app/components/route-details-header/route-details-header.tsx
+++ b/app/components/route-details-header/route-details-header.tsx
@@ -102,7 +102,7 @@ export const RouteDetailsHeader = React.memo(function RouteDetailsHeader(props: 
 
       <View style={{ top: -20, marginBottom: -30, zIndex: 5 }}>
         <View style={[ROUTE_DETAILS_WRAPPER, style]}>
-          <View style={[ROUTE_DETAILS_STATION, { marginStart: !isRTL ? spacing[5] : 0, marginEnd: isRTL ? spacing[5] : 0 }]}>
+          <View style={[ROUTE_DETAILS_STATION, { marginEnd: spacing[5] }]}>
             <Text style={ROUTE_DETAILS_STATION_TEXT} maxFontSizeMultiplier={1.1}>
               {originName}
             </Text>


### PR DESCRIPTION
On LTR mode, the route details header displays the stations swapped (origin station becomes the destination and vice versa)


<div style="display:flex;">
<img src="https://user-images.githubusercontent.com/13344923/117400674-d0f2b480-af0b-11eb-9eb8-7452c55dd140.jpg" alt="182493324_10157661985246326_9040800072546539792_n" width="300">
<img src="https://user-images.githubusercontent.com/13344923/117400678-d223e180-af0b-11eb-8c0d-fdead6023dd9.jpg" alt="182539781_10157661985456326_5889299588407291577_n" width="300">
</div>

This PR fixes the issue by removing the layout reversing on LTR mode.

<img src="https://user-images.githubusercontent.com/13344923/117401012-69893480-af0c-11eb-912e-b64e37a2fc5a.png" alt="Simulator Screen Shot - iPhone 11 - 2021-05-07 at 08 15 05" width="300">
