### PR TITLE
Fixed tomorrow day bug

### DIFF
--- a/app/i18n/formatted-date.ts
+++ b/app/i18n/formatted-date.ts
@@ -1,9 +1,8 @@
 import { formatRelative, differenceInMinutes } from "date-fns"
 import { dateFnsLocalization, translate } from "."
 
-const now = new Date()
-
 export function useFormattedDate(date: Date) {
+  const now = new Date()
   if (differenceInMinutes(date, now) < 2) return translate("plan.now")
   return formatRelative(date, now, { locale: dateFnsLocalization })
 }


### PR DESCRIPTION
Closes #84 

It happened becouse the `now` variable was stuck on the previous day if the app was at the background for a long time. So now we'll recreate it every time we need to calculate the formatted date.