### PR TITLE
Reset date to now button in route planner

### DIFF
--- a/app/components/date-picker-modal/date-picker-modal.android.tsx
+++ b/app/components/date-picker-modal/date-picker-modal.android.tsx
@@ -36,6 +36,7 @@ const CANCEL_BUTTON: ViewStyle = {
 
 export interface DatePickerModalProps {
   isVisible: boolean
+  onNow: () => void
   onChange: (date: Date) => void
   onConfirm: (date: Date) => void
   onCancel: () => void
@@ -45,7 +46,7 @@ export interface DatePickerModalProps {
 
 export const DatePickerModal = observer(function DatePickerModal(props: DatePickerModalProps) {
   const { routePlan } = useStores()
-  const { isVisible, onConfirm, onCancel, minimumDate } = props
+  const { isVisible, onConfirm, onCancel, onNow, minimumDate } = props
   const [selectedTab, setSelectedTab] = useState(0)
 
   const onDateTypeChange = (selectedTabIndex: number) => {
@@ -53,8 +54,10 @@ export const DatePickerModal = observer(function DatePickerModal(props: DatePick
 
     if (selectedTabIndex === 0) {
       routePlan.setDateType("departure")
-    } else {
+    } else if (selectedTabIndex === 1) {
       routePlan.setDateType("arrival")
+    } else {
+      onNow()
     }
   }
 
@@ -65,7 +68,7 @@ export const DatePickerModal = observer(function DatePickerModal(props: DatePick
     <Modal style={MODAL_WRAPPER} isVisible={isVisible} onBackButtonPress={onCancel} statusBarTranslucent>
       <View style={{ flex: 1, width: "100%", padding: spacing[2] }}>
         <MaterialTabs
-          items={[translate("plan.leaveAt"), translate("plan.arriveAt")]}
+          items={[translate("plan.leaveAt"), translate("plan.arriveAt"), translate("plan.now")]}
           selectedIndex={selectedTab}
           onChange={onDateTypeChange}
           barColor={isDarkMode ? "#010101" : "#fff"}

--- a/app/components/date-picker-modal/date-picker-modal.ios.tsx
+++ b/app/components/date-picker-modal/date-picker-modal.ios.tsx
@@ -47,7 +47,7 @@ export const DatePickerModal = observer(function DatePickerModal(props: DatePick
     () => (
       <View style={DATEPICKER_HEADER} onLayout={(e) => setHeaderWidth(e.nativeEvent.layout.width)}>
         <SegmentedControl
-          style={{ width: headerWidth - nowButtonWidth - spacing[3] }}
+          style={{ width: headerWidth - nowButtonWidth - spacing[2] }}
           values={[translate("plan.leaveAt"), translate("plan.arriveAt")]}
           selectedIndex={routePlan.dateType === "departure" ? 0 : 1}
           onChange={(event) => {

--- a/app/components/date-picker-modal/date-picker-modal.ios.tsx
+++ b/app/components/date-picker-modal/date-picker-modal.ios.tsx
@@ -1,24 +1,34 @@
-import React, { useMemo } from "react"
-import { ViewStyle } from "react-native"
+import React, { useMemo, useState } from "react"
+import { TextStyle, TouchableOpacity, View, ViewStyle } from "react-native"
 import { observer } from "mobx-react-lite"
 import DateTimePickerModal from "react-native-modal-datetime-picker"
 import SegmentedControl from "@react-native-segmented-control/segmented-control"
 import { DateType, useStores } from "../../models"
 import { dateLocale, translate } from "../../i18n"
-import { spacing } from "../../theme"
+import { spacing, typography, color } from "../../theme"
 import HapticFeedback from "react-native-haptic-feedback"
+import { Text } from "../text/text"
 
 // A dictionary to set the date type according to the segmented control selected index
 const DATE_TYPE: { [key: number]: DateType } = { 0: "departure", 1: "arrival" }
 
-const SEGMENTED_CONTROL: ViewStyle = {
+const DATEPICKER_HEADER: ViewStyle = {
   marginHorizontal: spacing[3],
   marginTop: spacing[3],
   marginBottom: -6,
+  flexDirection: "row",
+  justifyContent: "space-between",
+  alignItems: "center",
+}
+
+const NOW_BUTTON_TEXT: TextStyle = {
+  fontFamily: typography.secondary,
+  color: color.primary,
 }
 
 export interface DatePickerModalProps {
   isVisible: boolean
+  onNow: () => void
   onChange: (date: Date) => void
   onConfirm: (date: Date) => void
   onCancel: () => void
@@ -28,21 +38,29 @@ export interface DatePickerModalProps {
 
 export const DatePickerModal = observer(function DatePickerModal(props: DatePickerModalProps) {
   const { routePlan } = useStores()
-  const { isVisible, onChange, onConfirm, onCancel, minimumDate } = props
+  const { isVisible, onChange, onConfirm, onCancel, onNow, minimumDate } = props
 
-  const dateTypeControl = useMemo(
+  const [headerWidth, setHeaderWidth] = useState(0)
+  const [nowButtonWidth, setNowButtonWidth] = useState(0)
+
+  const datePickerHeader = useMemo(
     () => (
-      <SegmentedControl
-        values={[translate("plan.leaveAt"), translate("plan.arriveAt")]}
-        selectedIndex={routePlan.dateType === "departure" ? 0 : 1}
-        onChange={(event) => {
-          routePlan.setDateType(DATE_TYPE[event.nativeEvent.selectedSegmentIndex])
-          HapticFeedback.trigger("impactLight")
-        }}
-        style={SEGMENTED_CONTROL}
-      />
+      <View style={DATEPICKER_HEADER} onLayout={(e) => setHeaderWidth(e.nativeEvent.layout.width)}>
+        <SegmentedControl
+          style={{ width: headerWidth - nowButtonWidth - spacing[3] }}
+          values={[translate("plan.leaveAt"), translate("plan.arriveAt")]}
+          selectedIndex={routePlan.dateType === "departure" ? 0 : 1}
+          onChange={(event) => {
+            routePlan.setDateType(DATE_TYPE[event.nativeEvent.selectedSegmentIndex])
+            HapticFeedback.trigger("impactLight")
+          }}
+        />
+        <TouchableOpacity onPress={onNow} onLayout={(e) => setNowButtonWidth(e.nativeEvent.layout.width)}>
+          <Text style={NOW_BUTTON_TEXT}>{translate("plan.now")}</Text>
+        </TouchableOpacity>
+      </View>
     ),
-    [routePlan.dateType],
+    [routePlan.dateType, headerWidth, nowButtonWidth],
   )
 
   return (
@@ -56,7 +74,7 @@ export const DatePickerModal = observer(function DatePickerModal(props: DatePick
       locale={dateLocale}
       minimumDate={minimumDate}
       minuteInterval={15}
-      customHeaderIOS={() => dateTypeControl}
+      customHeaderIOS={() => datePickerHeader}
       customCancelButtonIOS={() => null}
       confirmTextIOS={translate("common.ok")}
     />

--- a/app/screens/planner/planner-screen.tsx
+++ b/app/screens/planner/planner-screen.tsx
@@ -110,6 +110,12 @@ export const PlannerScreen = observer(function PlannerScreen({ navigation }: Pla
     onDateChange(date)
   }
 
+  const handleNow = () => {
+    onDateChange(new Date())
+    setDatePickerVisibility(false)
+    routePlan.setDateType("departure")
+  }
+
   const originData = React.useMemo(() => {
     if (routePlan.origin) {
       return stations.find((s) => s.id === routePlan.origin.id)
@@ -276,6 +282,7 @@ export const PlannerScreen = observer(function PlannerScreen({ navigation }: Pla
           date={routePlan.date}
           onChange={onDateChange}
           onConfirm={handleConfirm}
+          onNow={handleNow}
           onCancel={() => setDatePickerVisibility(false)}
           minimumDate={now}
         />


### PR DESCRIPTION
Closes #60 

In iOS it adds a little button next to the date type control.
In Android it adds another tab named Now.

Functionality:
When the user clicks the button, the date selection modal automatically dismisses itself (to let the user get to the routes list faster) and changes the date type to "departure".