### PR TITLE
Fix grey out past routes in routes screen

### DIFF
--- a/app/components/route-card/route-card.tsx
+++ b/app/components/route-card/route-card.tsx
@@ -41,6 +41,10 @@ const ACTIVE_RIDE_CONTAINER: ViewStyle = {
   elevation: 2,
 }
 
+const PAST_RIDE_CONTAINER: ViewStyle = {
+  opacity: 0.4,
+}
+
 const TIME_TYPE_TEXT: TextStyle = {
   marginBottom: primaryFontIOS === "System" ? 1 : -2,
   fontFamily: typography.primary,
@@ -74,6 +78,7 @@ export interface RouteCardProps extends TouchableScaleProps {
   style?: ViewStyle
   isActiveRide: boolean
   shouldShowDashedLine?: boolean
+  isRouteInThePast: boolean
 }
 
 export const RouteCard = function RouteCard(props: RouteCardProps) {
@@ -111,7 +116,7 @@ export const RouteCard = function RouteCard(props: RouteCardProps) {
       onPress={onPress}
       activeScale={0.95}
       friction={9}
-      style={[CONTAINER, props.isActiveRide && ACTIVE_RIDE_CONTAINER, style]}
+      style={[CONTAINER, props.isActiveRide && ACTIVE_RIDE_CONTAINER, props.isRouteInThePast && PAST_RIDE_CONTAINER, style]}
     >
       <View style={{ marginEnd: spacing[3] }}>
         <Text style={TIME_TYPE_TEXT} tx="routes.departure" />

--- a/app/screens/route-details/components/start-ride-button.tsx
+++ b/app/screens/route-details/components/start-ride-button.tsx
@@ -5,8 +5,8 @@ import HapticFeedback from "react-native-haptic-feedback"
 import { Button } from "../../../components"
 import { isRTL, translate, userLocale } from "../../../i18n"
 import type { RouteItem } from "../../../services/api"
-import { differenceInMinutes, isAfter } from "date-fns"
-import { timezoneCorrection } from "../../../utils/helpers/date-helpers"
+import { differenceInMinutes } from "date-fns"
+import { isRouteInThePast, timezoneCorrection } from "../../../utils/helpers/date-helpers"
 import { color, fontScale } from "../../../theme"
 import { useStores } from "../../../models"
 import { AndroidNotificationSetting, AuthorizationStatus } from "@notifee/react-native"
@@ -55,7 +55,7 @@ export const StartRideButton = observer(function StartRideButton(props: StartRid
    * We are also correcting the user's timezone to Asia/Jerusalem, so if foreign users are playing with the
    * feature, it'll allow them to start a ride as if they were at Israel at the moment.
    */
-  const isRouteInPast = isAfter(timezoneCorrection(new Date()).getTime(), route.arrivalTime + route.delay * 60000)
+  const isRouteInPast = isRouteInThePast(route.arrivalTime, route.delay)
   const isRouteInFuture =
     differenceInMinutes(route.departureTime + route.delay * 60000, timezoneCorrection(new Date()).getTime()) > 60
 

--- a/app/screens/route-list/route-list-screen.tsx
+++ b/app/screens/route-list/route-list-screen.tsx
@@ -23,6 +23,7 @@ import {
 import { flatMap, max, round } from "lodash"
 import { translate } from "../../i18n"
 import type BottomSheet from "@gorhom/bottom-sheet/lib/typescript/components/bottomSheet/BottomSheet"
+import { isRouteInThePast } from "../../utils/helpers/date-helpers"
 
 const ROOT: ViewStyle = {
   backgroundColor: color.background,
@@ -344,6 +345,7 @@ export const RouteListScreen = observer(function RouteListScreen({ navigation, r
         arrivalTime={arrivalTime}
         delay={item.delay}
         isActiveRide={ride.isRouteActive(item)}
+        isRouteInThePast={isRouteInThePast(arrivalTime, item.delay)}
         onPress={() =>
           navigation.navigate("routeDetails", {
             routeItem: item,

--- a/app/utils/helpers/date-helpers.ts
+++ b/app/utils/helpers/date-helpers.ts
@@ -1,4 +1,4 @@
-import { differenceInMilliseconds, format, formatDuration, intervalToDuration, isWithinInterval, parse } from "date-fns"
+import { differenceInMilliseconds, format, formatDuration, intervalToDuration, isAfter, isWithinInterval, parse } from "date-fns"
 import { formatInTimeZone } from "date-fns-tz"
 import { dateDelimiter, dateFnsLocalization } from "../../i18n"
 
@@ -57,6 +57,10 @@ export function formatDateForAPI(date: number) {
   const formattedTime = format(date, "HH:mm")
 
   return [formattedDate, formattedTime]
+}
+
+export function isRouteInThePast(arrivalTime: number, delay: number) {
+  return isAfter(timezoneCorrection(new Date()).getTime(), arrivalTime + delay * 60000)
 }
 
 export const calculateDelayedTime = (time: string | Date | number, delay: number): string | undefined => {


### PR DESCRIPTION
grey out past routes in routes screen.
Add isRouteInThePast helper function and integrate into RouteCard and StartRideButton components.

I have fully tested this feature on Android and it works as expected.
I do not have access to a Mac, so I was unable to test this on an iOS simulator or device.

fixes #368 