### PR TITLE
Fix animation conflict caused by the opacity overlapping on iOS

### DIFF
--- a/app/components/route-details-header/route-details-header.tsx
+++ b/app/components/route-details-header/route-details-header.tsx
@@ -272,7 +272,6 @@ export const RouteDetailsHeader = observer(function RouteDetailsHeader(props: Ro
             {/* Back Button */}
             <View style={Platform.select({ android: { marginLeft: -spacing[4] }, ios: {} })}>
               <HeaderBackButton
-                // Using rgba instead of style={{ opacity }} to avoid animation conflicts with TouchableScale
                 tintColor="rgba(211, 211, 211, 0.9)"
                 onPress={() => navigation.goBack()}
               />


### PR DESCRIPTION
Changing custom header layout in order to fix Android 15 edge-to-edge in #467, caused some unwanted side effect on iOS with overlapping opacity animations.

This approach completely sidesteps the animation conflict while achieving the exact same visual appearance.