### PR TITLE
Update to support Kotlin 2.1.20

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -166,16 +166,16 @@ dependencies {
     implementation("androidx.cardview:cardview:1.0.0")
     
     // Hilt for dependency injection
-    implementation("com.google.dagger:hilt-android:2.48")
-    kapt("com.google.dagger:hilt-compiler:2.48")
+    implementation("com.google.dagger:hilt-android:2.53.1")
+    kapt("com.google.dagger:hilt-compiler:2.53.1")
     
     // DataStore for preferences
     implementation("androidx.datastore:datastore-preferences:1.0.0")
     
     // Room database for caching
-    implementation("androidx.room:room-runtime:2.6.1")
-    implementation("androidx.room:room-ktx:2.6.1")
-    kapt("androidx.room:room-compiler:2.6.1")
+    implementation("androidx.room:room-runtime:2.7.0")
+    implementation("androidx.room:room-ktx:2.7.0")
+    kapt("androidx.room:room-compiler:2.7.0")
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")

--- a/android/app/src/main/java/com/betterrail/MainApplication.kt
+++ b/android/app/src/main/java/com/betterrail/MainApplication.kt
@@ -49,8 +49,12 @@ class MainApplication : Application(), ReactApplication {
   override fun onCreate() {
     super.onCreate()
     
-    // Initialize React Native
-    loadReactNative(this)
+    // Initialize SoLoader
+    SoLoader.init(this, OpenSourceMergedSoMapping)
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // If you opted-in for React Native's New Architecture (also known as Fabric + TurboModules)
+      load()
+    }
     
     // Initialize widget lifecycle management
     try {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,8 +25,8 @@ buildscript {
         classpath("com.google.firebase:firebase-crashlytics-gradle:2.9.2")
         classpath("com.android.tools.build:gradle")
         classpath('com.facebook.react:react-native-gradle-plugin')
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
-        classpath("com.google.dagger:hilt-android-gradle-plugin:2.48")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+        classpath("com.google.dagger:hilt-android-gradle-plugin:2.53.1")
     }
 }
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4783,18 +4783,18 @@ SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   BoringSSL-GRPC: dded2a44897e45f28f08ae87a55ee4bcd19bc508
-  Burnt: dde5dd245f124a4594098e3938ba71aae4ec83c3
-  BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
+  Burnt: e3a3397e26172fca31a59bb27421475a58068836
+  BVLinearGradient: 44fd36b87f318e7933c4c91a6991442a5e3f5bcf
   ComputableLayout: c50faffac4ed9f8f05b0ce5e6f3a60df1f6042c8
   ContextMenuAuxiliaryPreview: 20be0be795b783b68f8792732eed4bed9f202c1c
   DGSwiftUtilities: 567f8d5ee618f0b7afb185b17aa45ff356315a0f
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  Expo: eb002e02be05e684bd45d57eb8716db8d70b530c
-  ExpoBlur: b5b7a26572b3c33a11f0b2aa2f95c17c4c393b76
-  ExpoCalendar: 46ad51c48d2cb1a95439c2215b182428919a0c3d
-  ExpoClipboard: 99109306a2d9ed2fbd16f6b856e6267b2afa8472
-  ExpoLocalization: 6c6f0f89ad2822001ab0bc2eb6d4d980c77f080c
-  ExpoModulesCore: 02bc7a835251516de8598a2388a38d7b1855eb17
+  Expo: cfaca1fa072088776e32355a9b25e64e0d47090f
+  ExpoBlur: 2dd8f64aa31f5d405652c21d3deb2d2588b1852f
+  ExpoCalendar: 34fe3956dab6278057a8ad04c648fe43bd642ef5
+  ExpoClipboard: af650d14765f19c60ce2a1eaf9dfe6445eff7365
+  ExpoLocalization: b852a5d8ec14c5349c1593eca87896b5b3ebfcca
+  ExpoModulesCore: b35c31110006050474d81c7a70c4fa3bfec7faab
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 86588b5a1547e7a417942a08f49559b184e002c8
   Firebase: 735108d2d0b67827cd929bfe8254983907c4479f
@@ -4826,108 +4826,108 @@ SPEC CHECKSUMS:
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
-  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
+  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 300c5eb91114d4339b0bb39505d0f4824d7299b7
   RCTRequired: e0446b01093475b7082fbeee5d1ef4ad1fe20ac4
   RCTTypeSafety: cb974efcdc6695deedf7bf1eb942f2a0603a063f
   React: e7a4655b09d0e17e54be188cc34c2f3e2087318a
   React-callinvoker: 62192daaa2f30c3321fc531e4f776f7b09cf892b
-  React-Core: c400b068fdb6172177f3b3fae00c10d1077244d7
-  React-CoreModules: 8e911a5a504b45824374eec240a78de7a6db8ca2
-  React-cxxreact: 06a91f55ac5f842219d6ca47e0f77187a5b5f4ac
+  React-Core: b23cdaaa9d76389d958c06af3c57aa6ad611c542
+  React-CoreModules: 8e0f562e5695991e455abbebe1e968af71d52553
+  React-cxxreact: 6ccbe0cc2c652b29409b14b23cfb3cd74e084691
   React-debug: ab52e07f7148480ea61c5e9b68408d749c6e2b8f
-  React-defaultsnativemodule: fab7bf1b5ce1f3ed252aa4e949ec48a8df67d624
-  React-domnativemodule: 735fa5238cceebceeecc18f9f4321016461178cf
-  React-Fabric: c75719fc8818049c3cf9071f0619af988b020c9f
-  React-FabricComponents: 74a381cc0dfaf2ec3ee29f39ef8533a7fd864b83
-  React-FabricImage: 9a3ff143b1ac42e077c0b33ec790f3674ace5783
-  React-featureflags: e1eca0727563a61c919131d57bbd0019c3bdb0f0
-  React-featureflagsnativemodule: 692211fd48283b2ddee3817767021010e2f1788e
-  React-graphics: 759b02bde621f12426c1dc1ae2498aaa6b441cd7
-  React-hermes: b6e33fcd21aa7523dc76e62acd7a547e68c28a5b
-  React-idlecallbacksnativemodule: 731552efc0815fc9d65a6931da55e722b1b3a397
-  React-ImageManager: 2c510a480f2c358f56a82df823c66d5700949c96
-  React-jserrorhandler: 411e18cbdcbdf546f8f8707091faeb00703527c1
-  React-jsi: 3fde19aaf675c0607a0824c4d6002a4943820fd9
-  React-jsiexecutor: 4f898228240cf261a02568e985dfa7e1d7ad1dfb
-  React-jsinspector: 2f0751e6a4fb840f4ed325384d0795a9e9afaf39
-  React-jsinspectorcdp: 71c48944d97f5f20e8e144e419ddf04ffa931e93
-  React-jsinspectornetwork: 102f347669b278644cc9bb4ebf2f90422bd5ccef
-  React-jsinspectortracing: 0f6f2ec7f3faa9dc73d591b24b460141612515eb
-  React-jsitooling: b557f8e12efdaf16997e43b0d07dbd8a3fce3a5b
-  React-jsitracing: f9a77561d99c0cd053a8230bab4829b100903949
-  React-logger: ea80169d826e0cd112fa4d68f58b2b3b968f1ecb
-  React-Mapbuffer: 230c34b1cabd1c4815726c711b9df221c3d3fbfb
-  React-microtasksnativemodule: 29d62f132e4aba34ebb7f2b936dde754eb08971b
-  react-native-actions-shortcuts: 241812296acd3d1b1babbb91d053f01be2810dcd
-  react-native-context-menu-view: 4a4de8bc59bc3fc4215f041881cbc6b2aeac31fe
-  react-native-date-picker: 50b4dfbe40efbe44d49f912d01a93a683423c455
-  react-native-in-app-review: db8bb167a5f238e7ceca5c242d6b36ce8c4404a4
-  react-native-ios-context-menu: ef4e3872094775ffd74a4b9f8287a2236699cae7
-  react-native-ios-utilities: 399e0178b15408f4fc5ed826c02f5da8e731e9a5
-  react-native-netinfo: 2517ad504b3d303e90d7a431b0fcaef76d207983
-  react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
-  react-native-safe-area-context: f8e20c4e9453e4bb545db6478495dc5b1128f504
-  react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
-  react-native-video: 71973843c2c9ac154c54f95a5a408fd8b041790e
-  React-NativeModulesApple: d061f458c3febdf0ac99b1b0faf23b7305974b25
+  React-defaultsnativemodule: 291d2b0a93c399056121f4f0acc7f46d155a38ec
+  React-domnativemodule: c4968302e857bd422df8eec50a3cd4d078bd4ac0
+  React-Fabric: 7e3ba48433b87a416052c4077d5965aff64cb8c9
+  React-FabricComponents: 21de255cf52232644d12d3288cced1f0c519b25d
+  React-FabricImage: 15a0961a0ab34178f1c803aa0a7d28f21322ffc3
+  React-featureflags: 4e5dad365d57e3c3656447dfdad790f75878d9f4
+  React-featureflagsnativemodule: 5eac59389131c2b87d165dac4094b5e86067fabb
+  React-graphics: 2f9b3db89f156afd793da99f23782f400f58c1ee
+  React-hermes: cc8c77acee1406c258622cd8abbee9049f6b5761
+  React-idlecallbacksnativemodule: 1d7e1f73b624926d16db956e87c4885ef485664a
+  React-ImageManager: 8b6066f6638fba7d4a94fbd0b39b477ea8aced58
+  React-jserrorhandler: e5a4626d65b0eda9a11c43a9f14d0423d8a7080d
+  React-jsi: ea5c640ea63c127080f158dac7f4f393d13d415c
+  React-jsiexecutor: cf7920f82e46fe9a484c15c9f31e67d7179aa826
+  React-jsinspector: 094e3cb99952a0024fa977fa04706e68747cba18
+  React-jsinspectorcdp: dca545979146e3ecbdc999c0789dab55beecc140
+  React-jsinspectornetwork: 0a105fe74b0b1a93f70409d955c8a0556dc17c59
+  React-jsinspectortracing: 76088dd78a2de3ea637a860cdf39a6d9c2637d6b
+  React-jsitooling: a2e1e87382aae2294bc94a6e9682b9bc83da1d36
+  React-jsitracing: 45827be59e673f4c54175c150891301138846906
+  React-logger: 7cfc7b1ae1f8e5fe5097f9c746137cc3a8fad4ce
+  React-Mapbuffer: 8f620d1794c6b59a8c3862c3ae820a2e9e6c9bb0
+  React-microtasksnativemodule: dcf5321c9a41659a6718df8a5f202af1577c6825
+  react-native-actions-shortcuts: 890ebc88c8d5da2700299d55d1c7b48bbbf4688c
+  react-native-context-menu-view: f72a7edd2a54cdb14e57a48ce8ac50d3b1602a9d
+  react-native-date-picker: 61aedfdfe66735334ecd7a0e46df9d2a396f8eca
+  react-native-in-app-review: b3d1eed3d1596ebf6539804778272c4c65e4a400
+  react-native-ios-context-menu: 66227b2076761fc7812cbbd6a827648e8819d843
+  react-native-ios-utilities: f48e125f20f0df5c994d5fb2f1c372eacb8f4fbe
+  react-native-netinfo: be701059f57093572e5ba08cba14483d334b425d
+  react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
+  react-native-safe-area-context: 62985d6ddaba032b8dafcd9d68ff278c625e959b
+  react-native-segmented-control: e21b475ecaec3b4e2c515d0276e0b22163c6590b
+  react-native-video: 4da16bfca01a02aa2095e40683d74f2d6563207c
+  React-NativeModulesApple: 342e280bb9fc2aa5f61f6c257b309a86b995e12d
   React-oscompat: 56d6de59f9ae95cd006a1c40be2cde83bc06a4e1
-  React-perflogger: 0633844e495d8b34798c9bf0cb32ce315f1d5c9f
-  React-performancetimeline: 53bdf62ff49a9b0c4bd4d66329fdcf28d77c1c9d
+  React-perflogger: 4008bd05a8b6c157b06608c0ea0b8bd5d9c5e6c9
+  React-performancetimeline: 3ac316a346fe3d48801a746b754dd8f5b5146838
   React-RCTActionSheet: 49138012280ec3bbb35193d8d09adb8bc61c982e
-  React-RCTAnimation: c7ed4a9d5a4e43c9b10f68bb43cd238c4a2e7e89
-  React-RCTAppDelegate: ea2ab6f4aef1489f72025b7128d8ab645b40eafb
-  React-RCTBlob: c052799460b245e1fffe3d1dddea36fa88e998a0
-  React-RCTFabric: fad6230640c42fb8cda29b1d0759f7a1fb8cc677
-  React-RCTFBReactNativeSpec: ffb22c3ee3d359ae9245ca94af203845da9371ec
-  React-RCTImage: 59fc2571f4f109a77139924f5babee8f9cd639c9
-  React-RCTLinking: a045cb58c08188dce6c6f4621de105114b1b16ce
-  React-RCTNetwork: fc7115a2f5e15ae0aa05e9a9be726817feefb482
-  React-RCTRuntime: c69b86dc60dcc7297318097fc60bd8e40b050f74
-  React-RCTSettings: 30d7dd7eae66290467a1e72bf42d927fa78c3884
-  React-RCTText: 755d59284e66c7d33bb4f0ccc428fe69110c3e74
-  React-RCTVibration: ffe019e588815df226f6f8ccdc65979f8b2bc440
+  React-RCTAnimation: ebfe7c62016d4c17b56b2cab3a221908ae46288d
+  React-RCTAppDelegate: 0108657ba9a19f6a1cd62dcd19c2c0485b3fc251
+  React-RCTBlob: 6cc309d1623f3c2679125a04a7425685b7219e6b
+  React-RCTFabric: 04d1cf11ee3747a699260492e319e92649d7ac88
+  React-RCTFBReactNativeSpec: ff3e37e2456afc04211334e86d07bf20488df0ae
+  React-RCTImage: bb98a59aeed953a48be3f917b9b745b213b340ab
+  React-RCTLinking: d6e9795d4d75d154c1dd821fd0746cc3e05d6670
+  React-RCTNetwork: 5c8a7a2dd26728323189362f149e788548ac72bc
+  React-RCTRuntime: 52b28e281aba881e1f94ee8b16611823b730d1c5
+  React-RCTSettings: b6a02d545ce10dd936b39914b32674db6e865307
+  React-RCTText: c7d9232da0e9b5082a99a617483d9164a9cd46e9
+  React-RCTVibration: fe636c985c1bf25e4a5b5b4d9315a3b882468a72
   React-rendererconsistency: aba18fa58a4d037004f6bed6bb201eb368016c56
-  React-renderercss: c7c140782f5f21103b638abfde7b3f11d6a5fd7e
-  React-rendererdebug: 111519052db9610f1b93baf7350c800621df3d0c
+  React-renderercss: b490bd53486a6bae1e9809619735d1f2b2cabd7f
+  React-rendererdebug: 8db25b276b64d5a1dbf05677de0c4ff1039d5184
   React-rncore: 22f344c7f9109b68c3872194b0b5081ca1aee655
-  React-RuntimeApple: 30d20d804a216eb297ccc9ce1dc9e931738c03b1
-  React-RuntimeCore: 6e1facd50e0b7aed1bc36b090015f33133958bb6
+  React-RuntimeApple: 19bdabedda0eeb70acb71e68bfc42d61bbcbacd9
+  React-RuntimeCore: 11bf03bdbd6e72857481c46d0f4eb9c19b14c754
   React-runtimeexecutor: b35de9cb7f5d19c66ea9b067235f95b947697ba5
-  React-RuntimeHermes: 222268a5931a23f095565c4d60e2673c04e2178a
-  React-runtimescheduler: aea93219348ba3069fe6c7685a84fe17d3a4b4ee
+  React-RuntimeHermes: d8f736d0a2d38233c7ec7bd36040eb9b0a3ccd8c
+  React-runtimescheduler: 0c95966d030c8ebbebddaab49630cda2889ca073
   React-timing: 42e8212c479d1e956d3024be0a07f205a2e34d9d
-  React-utils: 0ebf25dd4eb1b5497933f4d8923b862d0fe9566f
-  ReactAppDependencyProvider: 6c9197c1f6643633012ab646d2bfedd1b0d25989
-  ReactCodegen: f8ae44cfcb65af88f409f4b094b879591232f12c
-  ReactCommon: a237545f08f598b8b37dc3a9163c1c4b85817b0b
+  React-utils: a185f723baa0c525c361e6c281a846d919623dbe
+  ReactAppDependencyProvider: 8df342c127fd0c1e30e8b9f71ff814c22414a7c0
+  ReactCodegen: 4928682e20747464165effacc170019a18da953c
+  ReactCommon: ec1cdf708729338070f8c4ad746768a782fd9eb1
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
-  RNCAsyncStorage: 8da0e21a02370b8c41475f05ef3d003635b16f79
-  RNCMaskedView: bc0170f389056201c82a55e242e5d90070e18e5a
-  RNCPushNotificationIOS: 64218f3c776c03d7408284a819b2abfda1834bc8
-  RNDateTimePicker: 96f0ecc3cce39655604f47a7fe44468b70ef7a58
-  RNDefaultPreference: 08bdb06cfa9188d5da97d4642dac745218d7fb31
-  RNDeviceInfo: 475a4c447168d0ad4c807e48ef5e0963a0f4eb1b
-  RNFBAnalytics: c7e12de7bc87427a083ce13fad47ba0d0abb43d6
-  RNFBApp: 302c8bdbb0c8334033738a23db1ac08512821462
-  RNFBAuth: e21424838ed75e9a3c5ce157d38a3c873cd3ddcd
-  RNFBCrashlytics: d88591bda155301f6a6f5b573a7517150c24ace3
-  RNFBFirestore: c653384977d7156be402e520a788c25b56824c78
-  RNFBMessaging: af1ebc16b28e175a4278b263db731703a6aecc61
-  RNGestureHandler: 8c4c3ff641284e689208dc01e51d5c1e6807cf3c
-  RNIap: daac81aa70fe3ac6d6967c1c8da3dc4b415b73d6
-  RNInAppBrowser: e36d6935517101ccba0e875bac8ad7b0cb655364
-  RNNotifee: bc20a5e3d581f629db988075944fdd944d363dfe
-  RNReactNativeHapticFeedback: 8bd4a2ba7c3daeb5d2acfceb8b61743f203076d0
-  RNReanimated: d130bbb28f61440381f7295aae9430f7b09687c5
-  RNScreens: 68d326e021562426e82a4a04c90ddd309b9ad041
-  RNShare: b31e96b3be508b0e514727110cb1ec8d34c88f4e
-  RNSVG: 15b549eab93d3c7f1de4f7ab612a88132ebc1bca
-  RNWatch: fd30ca40a5b5ef58dcbc195638e68219bc455236
+  RNCAsyncStorage: febfe1e7b864c342fae240924d3d82c681d594a4
+  RNCMaskedView: 90a18f1e65b81985232eb6f5ea594300a4b6a09f
+  RNCPushNotificationIOS: 6c4ca3388c7434e4a662b92e4dfeeee858e6f440
+  RNDateTimePicker: 87557c780a44cd2ba53e485898c0dc1cb7abd744
+  RNDefaultPreference: ee13d69e6693d193cd223d10e15e5b3c012d31ba
+  RNDeviceInfo: e38f15f203e786b0a11bd7232d4b79ebcbb94a7c
+  RNFBAnalytics: 5eef65570a02641896e8c746a1fafb4ebeebfea8
+  RNFBApp: ce7a5efbd91af58a736234a90cb158a3f846be94
+  RNFBAuth: 3bb917b10252363d5e97c1113b20a31acf00f0a2
+  RNFBCrashlytics: d0ce28cff80c7f44199f7d914a2d3921e68a7b88
+  RNFBFirestore: 8416131bbaf4bd568c6427b4f29aaadda558f7f5
+  RNFBMessaging: 81c93473bf4242413bd42536ef19056a6714161a
+  RNGestureHandler: a52292df4f8fc7daab354ad2c37be401d4c3bed8
+  RNIap: d73cedfb73b396cad75f90f4ed7d64352d6381cf
+  RNInAppBrowser: 6d3eb68d471b9834335c664704719b8be1bfdb20
+  RNNotifee: 52b319634ba89a2eacdfbadc01e059fd18505f04
+  RNReactNativeHapticFeedback: d39b9a5b334ce26f49ca6abe9eea8b3938532aee
+  RNReanimated: 0b4147a00b6e539c484a12e182396dfc7443f310
+  RNScreens: 028db6b7a2454cefb7ef52afc9b6e3d07f55ac37
+  RNShare: df0a98323e01faa83606bdb505c6d5cfd9b11d62
+  RNSVG: 05951f386c4b23c484335dab2346f53e6210e8dc
+  RNWatch: 28fe1f5e0c6410d45fd20925f4796fce05522e3f
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SPAlert: 735da1f16a887e294719217572ce1f936d8c8782
   SPIndicator: 93e0a4fb23de51294ac48e874c0f081a5e293e4f
-  Yoga: 1e9b9a43e24807ab708430d5d1bf5e36a55a1c4d
+  Yoga: ce248fb32065c9b00451491b06607f1c25b2f1ed
 
 PODFILE CHECKSUM: 27f2519aaebd8de683dd2ac866daef71c00ee45b
 


### PR DESCRIPTION
* Updated Hilt to Support Kotlin 2.1.20
  * Updated Hilt plugin from 2.48 → 2.53.1
  * Updated Hilt dependencies from 2.48 → 2.53.1

* Replaced non-existent loadReactNative() function 
  * Used recommended SoLoader initialization
  * React Native's New Architecture הכנה למזגן

