### PR TITLE
Include device metadata in iOS feedback email

### DIFF
--- a/app/screens/settings/settings-about-screen.tsx
+++ b/app/screens/settings/settings-about-screen.tsx
@@ -49,17 +49,9 @@ const ABOUT_TEXT: TextStyle = {
   textAlign: "center",
 }
 
-// TODO: Add mail body to iOS - need to understand how to add newlines correctly
-const emailBody = Platform.select({
-  android: `%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A
----
-App: Better Rail ${getVersion()} (${getBuildNumber()})
-Device: ${getDeviceId()} (${getSystemVersion()})
-App Locale: ${userLocale}
-Device Locale: ${deviceLocale} 
-`,
-  ios: "",
-})
+const mailNewLine = Platform.OS === "ios" ? "%0A" : "%0D%0A"
+
+const emailBody = `${mailNewLine.repeat(10)}---${mailNewLine}App: Better Rail ${getVersion()} (${getBuildNumber()})${mailNewLine}Device: ${getDeviceId()} (${getSystemVersion()})${mailNewLine}App Locale: ${userLocale}${mailNewLine}Device Locale: ${deviceLocale}${mailNewLine}`
 
 export const AboutScreen = observer(function AboutScreen({ navigation }: SettingsScreenProps) {
   return (


### PR DESCRIPTION
## Summary
- reuse the Android feedback metadata formatting for iOS by defining a shared newline token
- append app, device, and locale information to the iOS feedback email body

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db093fc7008321a9d3be30cab21981