### PR TITLE
Fix crash when FCM notifications missing data payload

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -157,7 +157,7 @@ function App() {
   useEffect(() => {
     // open the announcements screen if the app was opened from a notification
     const unsubscribe = notifee.onForegroundEvent(({ type, detail }) => {
-      if (detail.notification.data?.type === "service-update") {
+      if (detail.notification?.data?.type === "service-update") {
         navigationRef.current?.navigate("announcementsStack")
       }
     })

--- a/app/utils/notification-helpers.ts
+++ b/app/utils/notification-helpers.ts
@@ -85,6 +85,8 @@ export const configureNotifications = async () => {
 }
 
 const handleLiveRideNotification = async (message: FirebaseMessagingTypes.RemoteMessage) => {
+  if (!message.data) return;
+
   if (message.data.notifee) {
     notifee.displayNotification({
       ...JSON.parse(message.data.notifee),
@@ -116,6 +118,8 @@ const handleLiveRideNotification = async (message: FirebaseMessagingTypes.Remote
 }
 
 const handleServiceUpdateNotification = async (message: FirebaseMessagingTypes.RemoteMessage) => {
+  if (!message.data) return;
+
   const { title, body, stations } = message.data
   const parsedStations = JSON.parse(stations)
 


### PR DESCRIPTION
I tried to trace this crash for `Cannot read property 'data' of undefined` and while the stack is not very clear, lurking the code, it seems like this is coming from the Live Ride Notifications and while I'm not entirely sure why `data` is sometimes `undefined`, whether it's a server issue or something else, I think adding early returns so it won't crash is an appropriate behavior.

```
Fatal Exception: com.facebook.react.common.JavascriptException: TypeError: Cannot read property 'data' of undefined, stack:
anonymous@1:799302
anonymous@1:1802709
emit@1:126474
anonymous@1:1806123
emit@1:126474
anonymous@1:123863
emit@1:124170

       at com.facebook.react.modules.core.ExceptionsManagerModule.reportException(ExceptionsManagerModule.kt:52)
       at com.facebook.jni.NativeRunnable.run(NativeRunnable.java)
       at android.os.Handler.handleCallback(Handler.java:959)
       at android.os.Handler.dispatchMessage(Handler.java:100)
       at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.kt:21)
       at android.os.Looper.loopOnce(Looper.java:257)
       at android.os.Looper.loop(Looper.java:342)
       at com.facebook.react.bridge.queue.MessageQueueThreadImpl$Companion.startNewBackgroundThread$lambda$1(MessageQueueThreadImpl.kt:175)
       at com.facebook.react.bridge.queue.MessageQueueThreadImpl$Companion.$r8$lambda$ldnZnqelhYFctGaUKkOKYj5rxo4()
       at com.facebook.react.bridge.queue.MessageQueueThreadImpl$Companion$$ExternalSyntheticLambda0.run(D8$$SyntheticClass)
       at java.lang.Thread.run(Thread.java:1012)
```

[full stack](https://github.com/user-attachments/files/23286749/com.betterrail_issue_77ff1260158bc72b21e24873621a5563_crash_session_69062B980294000101F650DF443BFD38_DNE_0_v2_stacktrace.txt)

@planecore WDYT?