### PR TITLE
Show Zolly announcement button only after 1 week install and 2 stations selected

### DIFF
--- a/app/screens/planner/planner-screen-header.tsx
+++ b/app/screens/planner/planner-screen-header.tsx
@@ -94,11 +94,30 @@ export function PlannerScreenHeader() {
   }, [])
 
   useEffect(() => {
-    if (!zollyFlag) return
-    storage.load("seenZollyAnnouncement").then((hasSeen) => {
-      if (!hasSeen) setShowZollyButton(true)
+    storage.load("appInstallDate").then((installDate) => {
+      if (!installDate) {
+        storage.save("appInstallDate", new Date().toISOString())
+      }
     })
-  }, [zollyFlag])
+  }, [])
+
+  useEffect(() => {
+    if (!zollyFlag) return
+    if (!origin || !destination) return
+
+    Promise.all([storage.load("seenZollyAnnouncement"), storage.load("appInstallDate")]).then(
+      ([hasSeen, installDate]) => {
+        if (hasSeen) return
+        if (!installDate) return
+
+        const oneWeekMs = 7 * 24 * 60 * 60 * 1000
+        const installedAt = new Date(installDate).getTime()
+        if (Date.now() - installedAt > oneWeekMs) {
+          setShowZollyButton(true)
+        }
+      },
+    )
+  }, [zollyFlag, origin, destination])
 
   const openAnnouncements = () => {
     navigation.navigate("announcementsStack")


### PR DESCRIPTION
The Zolly button now requires both origin and destination stations to be
selected and the app to have been installed for more than 1 week. An
appInstallDate is persisted to AsyncStorage on first launch to support
the time-based check.

https://claude.ai/code/session_01HFJNiQYTYwyX9ev52Uwmfe