### PR TITLE
🐛 - Fix feedback email body showing encoded characters on Android

### DIFF
--- a/app/screens/settings/settings-about-screen.tsx
+++ b/app/screens/settings/settings-about-screen.tsx
@@ -51,7 +51,17 @@ const ABOUT_TEXT: TextStyle = {
 const TWITTER_DEEP_LINK = "twitter://user?screen_name=better_rail"
 const TWITTER_WEB_URL = "https://x.com/better_rail"
 
-const emailBody = `\n\n\n\n\n\n\n\n\n---\nApp: Better Rail ${getVersion()} (${getBuildNumber()})\nDevice: ${getDeviceId()} (${getSystemVersion()})\nApp Locale: ${userLocale}\nDevice Locale: ${deviceLocale}\n`
+const emailBody = `
+
+
+
+
+---
+App: Better Rail ${getVersion()} (${getBuildNumber()})
+Device: ${getDeviceId()} (${getSystemVersion()})
+App Locale: ${userLocale}
+Device Locale: ${deviceLocale}
+`
 
 export function AboutScreen({ navigation }: SettingsScreenProps) {
   return (

--- a/app/screens/settings/settings-about-screen.tsx
+++ b/app/screens/settings/settings-about-screen.tsx
@@ -51,17 +51,7 @@ const ABOUT_TEXT: TextStyle = {
 const TWITTER_DEEP_LINK = "twitter://user?screen_name=better_rail"
 const TWITTER_WEB_URL = "https://x.com/better_rail"
 
-// TODO: Add mail body to iOS - need to understand how to add newlines correctly
-const emailBody = Platform.select({
-  android: `%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A
----
-App: Better Rail ${getVersion()} (${getBuildNumber()})
-Device: ${getDeviceId()} (${getSystemVersion()})
-App Locale: ${userLocale}
-Device Locale: ${deviceLocale}
-`,
-  ios: "",
-})
+const emailBody = `\n\n\n\n\n\n\n\n\n---\nApp: Better Rail ${getVersion()} (${getBuildNumber()})\nDevice: ${getDeviceId()} (${getSystemVersion()})\nApp Locale: ${userLocale}\nDevice Locale: ${deviceLocale}\n`
 
 export function AboutScreen({ navigation }: SettingsScreenProps) {
   return (


### PR DESCRIPTION
Fix double-encoding of newlines in the feedback email body, which caused literal `%0D%0A` characters to appear on Android.