### PR TITLE
Fix not-found route lookup handling

### DIFF
--- a/app/models/train-routes/train-routes.ts
+++ b/app/models/train-routes/train-routes.ts
@@ -88,7 +88,8 @@ export const useTrainRoutesStore = create<TrainRoutesStore>((set, get) => ({
     }
     // We couldn't find routes for the requested date.
     set({ resultType: "not-found", status: "done" })
-    throw new Error("Not found")
+    // "No routes" is an expected UI state, not an exceptional failure.
+    return []
   },
 }))
 


### PR DESCRIPTION
## Summary
- Stop throwing when route search exhausts fallback dates with no results
- Keep `resultType` set to `not-found` so the UI can show the empty-state message

## Testing
- Not run (not requested)