### PR TITLE
Fix route list showing transfer train delay instead of origin's

### DIFF
--- a/app/hooks/use-ride-progress/use-ride-route.ts
+++ b/app/hooks/use-ride-progress/use-ride-route.ts
@@ -3,7 +3,7 @@ import { useQueryClient } from "react-query"
 import { useEffect, useMemo, useState } from "react"
 import { formatDateForAPI } from "../../utils/helpers/date-helpers"
 import { RouteApi } from "../../services/api/route-api"
-import { findClosestStationInRoute, getSelectedRide } from "../../utils/helpers/ride-helpers"
+import { findClosestStationInRoute, getSelectedRide, getTrainFromStationId } from "../../utils/helpers/ride-helpers"
 import { useShallow } from "zustand/react/shallow"
 import { useRoutePlanStore, useRideStore } from "../../models"
 
@@ -54,10 +54,9 @@ export function useRideRoute(route: RouteItem) {
       setRoute(updatedRoute)
     }
 
-    setDelay(updatedRoute.delay)
-
     const stationId = findClosestStationInRoute(updatedRoute)
     setNextStationId(stationId)
+    setDelay(getTrainFromStationId(updatedRoute, stationId)?.delay ?? 0)
   }
 
   useEffect(() => {
@@ -69,7 +68,7 @@ export function useRideRoute(route: RouteItem) {
     // set the route details immidiately on mount
     const stationId = findClosestStationInRoute(route)
     setNextStationId(stationId)
-    setDelay(route.delay)
+    setDelay(getTrainFromStationId(route, stationId)?.delay ?? 0)
 
     // then check if there's a delay
     updateRide()

--- a/app/services/api/route-api.ts
+++ b/app/services/api/route-api.ts
@@ -5,7 +5,6 @@ import { RailApiGetRoutesResult } from "./rail-api.types"
 import { formatRouteDuration, isOneHourDifference, routeDurationInMs } from "../../utils/helpers/date-helpers"
 import { RouteItem } from "."
 import { getHours, parse, isSameDay, addDays } from "date-fns"
-import { findClosestStationInRoute, getTrainFromStationId } from "../../utils/helpers/ride-helpers"
 
 export class RouteApi {
   private api = railApi
@@ -115,13 +114,9 @@ export class RouteApi {
       })
 
       const routesWithWarning = formattedRoutes.map((route) => {
-        const nextStationId = findClosestStationInRoute(route)
-        const train = getTrainFromStationId(route, nextStationId)
-
-        const delay = train.delay
         const isMuchLonger = isRouteIsMuchLongerThanOtherRoutes(route, formattedRoutes)
         const isMuchShorter = isRouteMuchShorterThanOtherRoutes(route, formattedRoutes)
-        return Object.assign({}, route, { isMuchShorter, isMuchLonger, delay })
+        return Object.assign({}, route, { isMuchShorter, isMuchLonger })
       })
 
       return routesWithWarning


### PR DESCRIPTION
The route list delay badge was sourced from route.delay, which getRoutes()
overrode with the delay of whichever leg contained the station closest to
"now" (via findClosestStationInRoute). For a route in the past whose
origin train already departed, that lookup walked into the transfer leg
and surfaced its delay next to the original 15:43 departure time, even
though the origin train's actual delay was much smaller.

Keep route.delay pinned to trains[0].delay so it consistently describes
the leg that owns route.departureTime, and have useRideRoute compute the
active-leg delay locally — it already calls findClosestStationInRoute
for the station id.