### PR TITLE
🐛 - Cap home shortcuts to 4 to prevent Android crash

### DIFF
--- a/app/models/favorites/favorites.ts
+++ b/app/models/favorites/favorites.ts
@@ -76,17 +76,23 @@ export const useFavoritesStore = create<FavoritesStore>((set, get) => ({
     const toText = (route: FavoriteRoute) =>
       translate("favorites.toStation", { stationName: stationsObject[route.destinationId][stationLocale] })
 
+    // Both iOS quick actions and Android dynamic shortcuts cap at ~4-5 per app;
+    // some Android devices report lower limits and throw if exceeded.
+    const MAX_HOME_SHORTCUTS = 4
+
     Shortcuts.setShortcuts(
-      get().routes.map((route) => ({
-        type: `favorite-${route.id}`,
-        title: route.label || fromText(route),
-        subtitle: !route.label && toText(route),
-        iconName: "star",
-        data: {
-          originId: route.originId,
-          destinationId: route.destinationId,
-        },
-      })),
+      get()
+        .routes.slice(0, MAX_HOME_SHORTCUTS)
+        .map((route) => ({
+          type: `favorite-${route.id}`,
+          title: route.label || fromText(route),
+          subtitle: !route.label && toText(route),
+          iconName: "star",
+          data: {
+            originId: route.originId,
+            destinationId: route.destinationId,
+          },
+        })),
     )
   },
 


### PR DESCRIPTION
## Summary
- Slice favorite routes to a max of 4 before calling `Shortcuts.setShortcuts`
- Prevents `IllegalArgumentException: Max number of dynamic shortcuts exceeded` on Android devices whose `getMaxShortcutCountPerActivity()` is lower than the number of saved favorites (reported on Samsung SM-A155F running Android 16). iOS also caps quick actions at 4, so the same constant is safe cross-platform.

## Test plan
- [ ] Add 5+ favorite routes on Android and verify the app no longer crashes
- [ ] Confirm the first 4 favorites still appear as home-screen shortcuts on Android and iOS