### PR TITLE
Fix Android RTL direction stuck after language change

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -86,7 +86,14 @@ export function setUserLanguage(languageCode: LanguageCode, allowRestart = false
   }
 
   if (allowRestart) {
-    RNRestart.Restart()
+    // On Android, SharedPreferences.apply() is asynchronous. Without a delay,
+    // Runtime.exit(0) in RNRestart can race with the async write and lose the
+    // forceRTL preference, causing the UI direction to stay stale after restart.
+    if (Platform.OS === "android") {
+      setTimeout(() => RNRestart.Restart(), 300)
+    } else {
+      RNRestart.Restart()
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- On Android, switching languages didn't update the UI direction until a full cold app relaunch
- Root cause: React Native's `I18nUtil.kt` uses `SharedPreferences.apply()` (async disk write) to persist the `forceRTL` preference. `RNRestart.Restart()` then immediately calls `Runtime.exit(0)`, killing the process before the write flushes — so the preference is lost
- On next launch, `I18nManager.isRTL` reads the stale value, and the module-level `const isRTL = I18nManager.isRTL` bakes in the wrong direction for the whole session
- Fix: add a 300ms delay on Android before calling `RNRestart.Restart()` to let `SharedPreferences.apply()` complete
