### PR TITLE
💄 - Use Heebo font on Android

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -17,7 +17,9 @@ const APPLE_TEAM_ID = "UE6BVYPPFX"
 const IOS_BUNDLE_ID = "il.co.better-rail"
 const ANDROID_PACKAGE = "com.betterrail"
 
-const HEEBO_FONTS = [
+// iOS registers fonts by the family name baked into each file ("Heebo"), selecting the weight
+// via `fontWeight`. The flat string array is all iOS needs.
+const HEEBO_FONTS_IOS = [
   "./assets/fonts/Heebo-Black.otf",
   "./assets/fonts/Heebo-Bold.otf",
   "./assets/fonts/Heebo-ExtraBold.otf",
@@ -26,6 +28,23 @@ const HEEBO_FONTS = [
   "./assets/fonts/Heebo-Regular.otf",
   "./assets/fonts/Heebo-Thin.otf",
 ]
+
+// Android can't weight-select within a family from loose asset files — each file would be its own
+// family (e.g. "Heebo-Bold"). The object form makes expo-font emit an XML font resource and call
+// ReactFontManager.addCustomFont("Heebo", …), so `fontFamily: "Heebo"` + `fontWeight` resolves to
+// the right file natively, matching iOS. (Heebo has no 600/SemiBold file; Android picks the nearest.)
+const HEEBO_FONT_ANDROID = {
+  fontFamily: "Heebo",
+  fontDefinitions: [
+    { path: "./assets/fonts/Heebo-Thin.otf", weight: 100 },
+    { path: "./assets/fonts/Heebo-Light.otf", weight: 300 },
+    { path: "./assets/fonts/Heebo-Regular.otf", weight: 400 },
+    { path: "./assets/fonts/Heebo-Medium.otf", weight: 500 },
+    { path: "./assets/fonts/Heebo-Bold.otf", weight: 700 },
+    { path: "./assets/fonts/Heebo-ExtraBold.otf", weight: 800 },
+    { path: "./assets/fonts/Heebo-Black.otf", weight: 900 },
+  ],
+}
 
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
@@ -153,7 +172,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         },
       },
     ],
-    ["expo-font", { fonts: HEEBO_FONTS }],
+    ["expo-font", { ios: { fonts: HEEBO_FONTS_IOS }, android: { fonts: [HEEBO_FONT_ANDROID] } }],
     "@react-native-firebase/app",
     [
       "@sentry/react-native/expo",

--- a/src/components/route-card/route-card.tsx
+++ b/src/components/route-card/route-card.tsx
@@ -4,7 +4,6 @@ import { TextStyle, View, ViewStyle, Platform, TouchableOpacity, Pressable, Imag
 import TouchableScale, { TouchableScaleProps } from "react-native-touchable-scale"
 import { Svg, Line } from "react-native-svg"
 import { color, spacing, typography, fontScale } from "@/theme"
-import { primaryFontIOS } from "@/theme/typography"
 import { Text } from "@/components/text/text"
 import { format } from "date-fns"
 import { translate } from "@/i18n"
@@ -124,7 +123,7 @@ const PAST_RIDE_CONTAINER: ViewStyle = {
 }
 
 const TIME_TYPE_TEXT: TextStyle = {
-  marginBottom: primaryFontIOS === "System" ? 1 : -2,
+  marginBottom: -2,
   fontFamily: typography.primary,
   fontSize: 14,
   fontWeight: "500",
@@ -139,7 +138,7 @@ const TIME_TEXT: TextStyle = {
 }
 
 const DURATION_TEXT: TextStyle = {
-  marginBottom: primaryFontIOS === "System" ? 2 : -2,
+  marginBottom: -2,
   fontSize: 16,
 }
 

--- a/src/hooks/use-font-family.ts
+++ b/src/hooks/use-font-family.ts
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react"
-import { Platform } from "react-native"
 import * as storage from "@/utils/storage"
 
 /**
  * For cases when the System font is wanted to be used instead of Heebo, when the app is
- * being used in English (The iOS default english font family is Heebo)
+ * being used in English (the System font reads better than Heebo for Latin text).
+ * Heebo is now bundled on both iOS and Android, so non-English locales get Heebo on either platform.
  */
 export function useFontFamily() {
   const [fontFamily, setFontFamily] = useState("System")
@@ -12,7 +12,7 @@ export function useFontFamily() {
   useEffect(() => {
     storage.load("appLanguage").then((languageCode) => {
       if (languageCode) {
-        const isHeebo = languageCode !== "en" && Platform.OS === "ios"
+        const isHeebo = languageCode !== "en"
         if (isHeebo) setFontFamily("Heebo")
       }
     })

--- a/src/screens/planner/planner-screen.tsx
+++ b/src/screens/planner/planner-screen.tsx
@@ -5,7 +5,7 @@ import { Screen, Button, Text, StationCard, DummyInput, ChangeDirectionButton, R
 import { useShallow } from "zustand/react/shallow"
 import { useRoutePlanStore, useTrainRoutesStore, useDateTypeDisplayName } from "@/models"
 import HapticFeedback from "react-native-haptic-feedback"
-import { color, primaryFontIOS, spacing } from "@/theme"
+import { color, spacing } from "@/theme"
 import { useStations } from "@/data/stations"
 import { translate, useFormattedDate } from "@/i18n"
 import { DatePickerModal } from "@/components/date-picker-modal/date-picker-modal"
@@ -33,7 +33,7 @@ const CONTENT_WRAPPER: ViewStyle = {
 }
 
 const SCREEN_TITLE: TextStyle = {
-  marginBottom: primaryFontIOS === "System" ? 6 : 3,
+  marginBottom: 3,
 }
 
 const CHANGE_DIRECTION_WRAPPER: ViewStyle = {

--- a/src/screens/route-details/components/route-station-card.tsx
+++ b/src/screens/route-details/components/route-station-card.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { View, ViewStyle, Image, ImageStyle, TextStyle } from "react-native"
 import { Text } from "@/components"
 import { isRTL, translate } from "@/i18n"
-import { color, fontScale, primaryFontIOS, spacing } from "@/theme"
+import { color, fontScale, spacing } from "@/theme"
 
 const railwayStationIcon = require("../../../../assets/railway-station.png")
 
@@ -50,7 +50,7 @@ const ROUTE_DELAY_TIME: TextStyle = {
 }
 
 const ROUTE_STATION_NAME: TextStyle = {
-  marginBottom: primaryFontIOS === "System" ? 2 : -1,
+  marginBottom: -1,
   marginEnd: spacing[3],
   fontSize: 17,
   fontWeight: "700",

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,6 +1,9 @@
 import { Platform } from "react-native"
 
-export let primaryFontIOS = "Heebo"
+// Heebo is now registered on both platforms (see the expo-font config in app.config.ts —
+// iOS by family name, Android via an XML font family + ReactFontManager). Kept named
+// `primaryFontIOS` for backwards compatibility with the layout nudges that import it.
+export const primaryFontIOS = "Heebo"
 
 /**
  * You can find a list of available fonts on both iOS and Android here:
@@ -8,10 +11,7 @@ export let primaryFontIOS = "Heebo"
  *
  * If you're interested in adding a custom font to your project,
  * check out the readme file in ./assets/fonts/ then come back here
- * and enter your new font name. Remember the Android font name
- * is probably different than iOS.
- * More on that here:
- * https://github.com/lendup/react-native-cross-platform-text
+ * and enter your new font name.
  *
  * The various styles of fonts are defined in the <Text /> component.
  */
@@ -19,7 +19,7 @@ export const typography = {
   /**
    * The primary font.  Used in most places.
    */
-  primary: Platform.select({ ios: primaryFontIOS, android: "normal" }),
+  primary: Platform.select({ ios: primaryFontIOS, android: "Heebo" }),
 
   /**
    * An alternate font used for perhaps titles and stuff.

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,9 +1,8 @@
 import { Platform } from "react-native"
 
-// Heebo is now registered on both platforms (see the expo-font config in app.config.ts —
-// iOS by family name, Android via an XML font family + ReactFontManager). Kept named
-// `primaryFontIOS` for backwards compatibility with the layout nudges that import it.
-export const primaryFontIOS = "Heebo"
+// Heebo is registered on both platforms (see the expo-font config in app.config.ts —
+// iOS by family name, Android via an XML font family + ReactFontManager).
+export const primaryFont = "Heebo"
 
 /**
  * You can find a list of available fonts on both iOS and Android here:
@@ -17,9 +16,9 @@ export const primaryFontIOS = "Heebo"
  */
 export const typography = {
   /**
-   * The primary font.  Used in most places.
+   * The primary font.  Used in most places. Heebo on both platforms.
    */
-  primary: Platform.select({ ios: primaryFontIOS, android: "Heebo" }),
+  primary: primaryFont,
 
   /**
    * An alternate font used for perhaps titles and stuff.


### PR DESCRIPTION
Android previously fell back to the system font (Roboto) because the bundled Heebo files were only copied as loose assets with no weight-mapped family. This registers Heebo as a proper Android XML font family via the expo-font plugin's object form (which emits the font resource and a `ReactFontManager.addCustomFont("Heebo", …)` call), so `fontFamily: "Heebo"` + `fontWeight` resolves natively just like iOS. `typography.primary` now uses Heebo on Android, and the System-vs-Heebo language logic in `useFontFamily` applies on Android too. Verified on an Android emulator — Hebrew text renders in Heebo (English looks unchanged since Heebo's Latin glyphs are Roboto). Note: this is a native change (new font XML + MainApplication registration), so it requires a fresh native build, not an OTA update.