### PR TITLE
Fix Hebrew bet mixed into Cyrillic in Tayyiba Russian translation

### DIFF
--- a/ios-native/app/stationsData.json
+++ b/ios-native/app/stationsData.json
@@ -538,7 +538,7 @@
       "id": "4300",
       "hebrew": "שומרון - טייבה",
       "english": "Shomron – Tayyiba",
-      "russian": "Шомрон – Тайבе",
+      "russian": "Шомрон – Тайбе",
       "arabic": "هشومرون – الطيبة"
    },
    {

--- a/targets/intent/stationsData.json
+++ b/targets/intent/stationsData.json
@@ -538,7 +538,7 @@
       "id": "4300",
       "hebrew": "שומרון - טייבה",
       "english": "Shomron – Tayyiba",
-      "russian": "Шомрон – Тайבе",
+      "russian": "Шомрон – Тайбе",
       "arabic": "هشومرون – الطيبة"
    },
    {

--- a/targets/watch-widget/stationsData.json
+++ b/targets/watch-widget/stationsData.json
@@ -538,7 +538,7 @@
       "id": "4300",
       "hebrew": "שומרון - טייבה",
       "english": "Shomron – Tayyiba",
-      "russian": "Шомрон – Тайבе",
+      "russian": "Шомрон – Тайбе",
       "arabic": "هشومرون – الطيبة"
    },
    {

--- a/targets/watch/stationsData.json
+++ b/targets/watch/stationsData.json
@@ -538,7 +538,7 @@
       "id": "4300",
       "hebrew": "שומרון - טייבה",
       "english": "Shomron – Tayyiba",
-      "russian": "Шомрон – Тайבе",
+      "russian": "Шомрон – Тайбе",
       "arabic": "هشومرون – الطيبة"
    },
    {

--- a/targets/widget/stationsData.json
+++ b/targets/widget/stationsData.json
@@ -538,7 +538,7 @@
       "id": "4300",
       "hebrew": "שומרון - טייבה",
       "english": "Shomron – Tayyiba",
-      "russian": "Шомрон – Тайבе",
+      "russian": "Шомрон – Тайбе",
       "arabic": "هشومرون – الطيبة"
    },
    {


### PR DESCRIPTION
## Summary
- Fixes a hidden Unicode bug in the Russian name for Shomron–Tayyiba station (4300)
- The character `ב` (Hebrew bet, U+05D1) was used instead of `б` (Cyrillic, U+0431) in `"Тайבе"`, making it look correct visually but encode incorrectly
- Affects all 5 native JSON station data files

## Test plan
- [ ] Verify Russian locale shows "Шомрон – Тайбе" correctly in station search

https://claude.ai/code/session_01FbhX7s9MF7iygy4K5uXFe2