### PR TITLE
📝 - Update README setup instructions for Expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,28 @@ Better Rail is an open source mobile client for Israel Railways, with an emphasi
 
 ## Overview
 
-Better Rail is written primarily with React Native. We also use Swift & SwiftUI to leverage native iOS functionalities.
+Better Rail is built with React Native. We also use Swift, SwiftUI and Kotlin to leverage the native platforms functionalities.
 
 ### Installation
 
-The following steps assumes your environment is already set up for running React Native apps.  
-If this is your first time, check out the [official set up guide](https://reactnative.dev/docs/set-up-your-environment) beforehand.
+The following steps assume your environment is already set up for running Expo / React Native apps (Xcode for iOS, Android Studio for Android).  
+If this is your first time, check out the [Expo local development setup guide](https://docs.expo.dev/get-started/set-up-your-environment/) beforehand.
 
 #### Prerequisites
 
-- **Bun**: This project uses Bun as the package manager. Please see the [Bun installation guide](https://bun.com/docs/installation) for instructions.
+- **Bun**: This project uses Bun as the package manager. See the [Bun installation guide](https://bun.com/docs/installation) for instructions.
+- **CocoaPods** (iOS only): required by the prebuild step. See the [installation guide](https://guides.cocoapods.org/using/getting-started.html#installation).
 
 #### Setup Steps
 
-- Fork the repo and clone to your machine.
-- Run `bun install`
-- **MacOS / Linux users**: Run `bun rename-dev-configs` to rename the firebase development configs.
-- **Windows users**: Duplicate the firebase configs in `/ios` and `/android/app`, and remove the `.development` suffix from the duplicated files.
-- Run `bun build-android` to generate the Android assets.
-- Run `bun start` to start the metro development server
-- Run the app with `bun ios` (to open the iPhone simulator) or `bun android` (for the Android simulator).
+- Fork the repo and clone it to your machine.
+- Run `bun install`.
+- Run `bun start` to start the development server.
+- Run the app with `bun ios` (to open the iPhone simulator) or `bun android` (for the Android emulator). The first run generates the native projects and may take a while.
 
-If you want to contribute and face issues during instllation, please reach out to us at feedback@better-rail.co.il and we'll try to help!
+> If you change anything that affects the native layer (config, plugins, native dependencies), run `bun prebuild` (or `bun prebuild:clean`) to regenerate the native projects.
+
+If you want to contribute and face issues during installation, please reach out to us at feedback@better-rail.co.il and we'll try to help!
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Better Rail is an open source mobile client for Israel Railways, with an emphasi
 
 ## Overview
 
-Better Rail is built with React Native. We also use Swift, SwiftUI and Kotlin to leverage the native platforms functionalities.
+Better Rail is built with React Native. We also use Swift, SwiftUI and Kotlin to leverage native platform functionalities.
 
 ### Installation
 
@@ -20,7 +20,7 @@ If this is your first time, check out the [Expo local development setup guide](h
 #### Prerequisites
 
 - **Bun**: This project uses Bun as the package manager. See the [Bun installation guide](https://bun.com/docs/installation) for instructions.
-- **CocoaPods** (iOS only): required by the prebuild step. See the [installation guide](https://guides.cocoapods.org/using/getting-started.html#installation).
+- **CocoaPods** (iOS only): Required by the prebuild step. See the [installation guide](https://guides.cocoapods.org/using/getting-started.html#installation).
 
 #### Setup Steps
 


### PR DESCRIPTION
Updates the README installation steps to match the Expo + EAS + CNG setup.

- Points to the Expo local development setup guide
- Drops the removed `rename-dev-configs` / `build-android` steps
- Documents the simplified `bun install` → `bun start` → `bun ios`/`bun android` flow
- Adds a note about re-running `bun prebuild` after native-layer changes

https://claude.ai/code/session_01FFdfdnG5o7MG2eLtb7eU86