### PR TITLE
📈 - Add EAS Observe for startup performance metrics

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -51,7 +51,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Better Rail",
   slug: "better-rail",
   owner: "better-rail",
-  version: "2.7.0",
+  version: "2.7.1",
   updates: {
     url: "https://u.expo.dev/b7819f45-8466-4c11-8628-3539099e6c78",
   },

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,6 +14,7 @@ import notifee from "@notifee/react-native"
 import * as Sentry from "@sentry/react-native"
 import { enableScreens } from "react-native-screens"
 import { PostHogProvider } from "posthog-react-native"
+import { ObserveRoot, useObserve } from "expo-observe"
 import { GestureHandlerRootView } from "react-native-gesture-handler"
 import { useIAP, initConnection, finishTransaction, getAvailablePurchases } from "react-native-iap"
 
@@ -104,6 +105,7 @@ function RootLayout() {
   const [localeReady, setLocaleReady] = useState(false)
   const appState = useRef(AppState.currentState)
   const router = useRouter()
+  const { markInteractive } = useObserve()
 
   useDeepLinking(storeReady)
 
@@ -198,6 +200,14 @@ function RootLayout() {
     }
   }, [])
 
+  useEffect(() => {
+    // Signal EAS Observe that the app is interactive once the store + locale are
+    // ready — this is the point we stop returning null and render the real UI.
+    if (storeReady && localeReady) {
+      markInteractive()
+    }
+  }, [storeReady, localeReady, markInteractive])
+
   if (!storeReady || !localeReady) return null
 
   return (
@@ -215,4 +225,4 @@ function RootLayout() {
   )
 }
 
-export default Sentry.wrap(RootLayout)
+export default Sentry.wrap(ObserveRoot.wrap(RootLayout))

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "expo-font": "~56.0.7",
         "expo-localization": "~56.0.6",
         "expo-network": "~56.0.5",
+        "expo-observe": "~56.0.21",
         "expo-router": "~56.2.11",
         "expo-store-review": "~56.0.3",
         "expo-updates": "~56.0.19",
@@ -1222,6 +1223,8 @@
 
     "expo": ["expo@56.0.12", "", { "dependencies": { "@babel/runtime": "^7.20.0", "@expo/cli": "^56.1.16", "@expo/config": "~56.0.9", "@expo/config-plugins": "~56.0.9", "@expo/devtools": "~56.0.2", "@expo/dom-webview": "~56.0.5", "@expo/fingerprint": "^0.19.4", "@expo/local-build-cache-provider": "^56.0.8", "@expo/log-box": "^56.0.13", "@expo/metro": "~56.0.0", "@expo/metro-config": "~56.0.14", "@ungap/structured-clone": "^1.3.0", "babel-preset-expo": "~56.0.15", "expo-asset": "~56.0.17", "expo-constants": "~56.0.18", "expo-file-system": "~56.0.8", "expo-font": "~56.0.7", "expo-keep-awake": "~56.0.3", "expo-modules-autolinking": "~56.0.16", "expo-modules-core": "~56.0.17", "pretty-format": "^29.7.0", "react-refresh": "^0.14.2", "whatwg-url-minimum": "^0.1.2" }, "peerDependencies": { "@expo/metro-runtime": "*", "react": "*", "react-dom": "*", "react-native": "*", "react-native-web": "*", "react-native-webview": "*" }, "optionalPeers": ["@expo/metro-runtime", "react-dom", "react-native-web", "react-native-webview"], "bin": { "expo": "bin/cli", "fingerprint": "bin/fingerprint", "expo-modules-autolinking": "bin/autolinking" } }, "sha512-FxgdI/Yqva6iJOThZIHfvxlKPxs4EC4uScUnEswwSArR/Fj9k430O13R590LcOQTsdNsjIs+GBHwjfoAY6vmAQ=="],
 
+    "expo-app-metrics": ["expo-app-metrics@56.0.19", "", { "dependencies": { "expo-updates-interface": "~56.0.1" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-Gzayufrhb5G8QVTANtbEViFb0ebxbD09kZ0q/ROibvh4On+yeDkZe64GPxHftLnQ5WvFc3aAOuZWS+NxLfz7yQ=="],
+
     "expo-asset": ["expo-asset@56.0.17", "", { "dependencies": { "@expo/image-utils": "^0.10.1", "expo-constants": "~56.0.18" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-GFN5j+8SPkyv0nfsiFHewmdB/D0tL237TsBE/gSfFOFy/J3a52py7IulcSqkA3sQE/u/UlD5BmvP5ssS4//nUg=="],
 
     "expo-blur": ["expo-blur@56.0.3", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-KDDtrpWc2tYlm1WCPaOgBtv+YEGqe5ELheFPIgSNgHt28NQUDcfBcFsA9Us2StDh6osmSD6NbKxOt5bU6PcDbQ=="],
@@ -1267,6 +1270,8 @@
     "expo-modules-jsi": ["expo-modules-jsi@56.0.10", "", { "peerDependencies": { "react-native": "*" } }, "sha512-fHZcFpYO/o62GYa6fJyAQJZcAShzhoN0iMMDzbr7vD3ewET6e1vAlTonbEakN9F0VHEgBFJ4NREy87uwVcpCuA=="],
 
     "expo-network": ["expo-network@56.0.5", "", { "peerDependencies": { "expo": "*", "react": "*" } }, "sha512-zmuyO95jayDY9jyUfOAlNp9XXJrJaAOkBXXLy0TS/nh2kppj7CHirRPkQ/tf0rsxhIL3AEd9nsRTiPtNsGT9Lw=="],
+
+    "expo-observe": ["expo-observe@56.0.21", "", { "dependencies": { "expo-app-metrics": "~56.0.19", "expo-eas-client": "~56.0.0" }, "peerDependencies": { "@react-navigation/native": "^7.0.0", "expo": "*", "expo-router": "*", "react": "*", "react-native": "*" }, "optionalPeers": ["@react-navigation/native", "expo-router"] }, "sha512-8gBYtSWsoU7QHdXVv1uwOcJvxxg5oewn9R0MnPqYEHil+sJPgz3mbdsmYMbYHSrC8PvBqMj9i+guvd0PElpb5w=="],
 
     "expo-router": ["expo-router@56.2.11", "", { "dependencies": { "@expo/log-box": "^56.0.13", "@expo/metro-runtime": "^56.0.15", "@expo/schema-utils": "^56.0.0", "@expo/ui": "^56.0.18", "@radix-ui/react-slot": "^1.2.0", "@radix-ui/react-tabs": "^1.1.12", "@react-native-masked-view/masked-view": "^0.3.2", "@testing-library/jest-dom": "^6.9.1", "@testing-library/user-event": "^14.6.1", "client-only": "^0.0.1", "color": "^4.2.3", "debug": "^4.3.4", "escape-string-regexp": "^4.0.0", "expo-glass-effect": "^56.0.4", "expo-server": "^56.0.5", "expo-symbols": "^56.0.6", "fast-deep-equal": "^3.1.3", "invariant": "^2.2.4", "nanoid": "^3.3.8", "query-string": "^7.1.3", "react-fast-compare": "^3.2.2", "react-is": "^19.1.0", "react-native-drawer-layout": "^4.2.2", "react-native-screens": "^4.25.2", "server-only": "^0.0.1", "sf-symbols-typescript": "^2.1.0", "shallowequal": "^1.1.0", "standard-navigation": "^0.0.5", "vaul": "^1.1.2" }, "peerDependencies": { "@testing-library/react-native": ">= 13.2.0", "expo": "*", "expo-constants": "^56.0.18", "expo-linking": "^56.0.14", "react": "*", "react-dom": "*", "react-native": "*", "react-native-gesture-handler": "*", "react-native-reanimated": "*", "react-native-safe-area-context": ">= 5.4.0", "react-native-web": "*", "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4" }, "optionalPeers": ["@testing-library/react-native", "react-dom", "react-native-gesture-handler", "react-native-reanimated", "react-native-web", "react-server-dom-webpack"] }, "sha512-08DBTrKv3QanOc9u1JNxSEChW9c/qNFbQ0dO28OLvufWWfdSRkSdHmh365D2FgoZg1qaOzZPCDuL3tM6nGSfkQ=="],
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "expo-font": "~56.0.7",
     "expo-localization": "~56.0.6",
     "expo-network": "~56.0.5",
+    "expo-observe": "~56.0.21",
     "expo-router": "~56.2.11",
     "expo-store-review": "~56.0.3",
     "expo-updates": "~56.0.19",


### PR DESCRIPTION
## Summary
Adds [EAS Observe](https://docs.expo.dev/eas/observe/) to track app-startup performance (cold/warm launch, TTR, TTI) from production builds.

## Changes
- Install `expo-observe@~56.0.21` (SDK 56-compatible).
- Wrap the root layout export with `ObserveRoot.wrap(...)` (composed with the existing `Sentry.wrap`) — measures **Time to First Render** automatically.
- Call `markInteractive()` via the `useObserve()` hook once `storeReady && localeReady` — i.e. exactly when the app stops rendering `null` and shows real UI — to record **Time to Interactive**.
- Bump app version to `2.7.1`.

## Notes
- Metrics only dispatch from real release builds (debug/dev builds are ignored by default), so data appears after the next `eas build`, under the **Observe** tab in the EAS dashboard.
- `markInteractive()` is placed in the root ready-gate, covering normal launches. Deep-link launches into a modal/screen aren't separately tracked yet — the optional per-route Expo Router integration could be added later if we want per-screen TTI.

https://claude.ai/code/session_01HGgWseHtmPxgmsJuhXyWB5