### PR TITLE
🐛 - Add missing station image fields in ios-native stationsData

### DIFF
--- a/ios-native/app/stationsData.json
+++ b/ios-native/app/stationsData.json
@@ -532,7 +532,8 @@
       "hebrew": "חדרה - מזרח",
       "english": "Hadera - East",
       "russian": "Хадера – Восток",
-      "arabic": "حديرا - شرق"
+      "arabic": "حديرا - شرق",
+      "image": "hadera-east"
    },
    {
       "id": "4300",
@@ -547,6 +548,7 @@
       "hebrew": "טירה - כוכב יאיר",
       "english": "Tira - Kokhav Ya'ir",
       "russian": "Тира – Кохав-Яир",
-      "arabic": "الطيرة - كوخاڤ يَئير"
+      "arabic": "الطيرة - كوخاڤ يَئير",
+      "image": "tira-kokhav-yair"
    }
 ]


### PR DESCRIPTION
## What

Adds the missing `"image"` field to `ios-native/app/stationsData.json` for two stations:

- **3900** – Hadera - East → `"hadera-east"`
- **4310** – Tira - Kokhav Ya'ir → `"tira-kokhav-yair"`

## Why

These stations already have their image assets referenced in `src/data/stations.ts` and in the other `stationsData.json` files (`intent`, `watch`, `watch-widget`, `widget`), but the `ios-native/app` copy was left out — likely an oversight from #635. This change brings the data back in sync across all targets.

The referenced image names (`hadera-east`, `tira-kokhav-yair`) already have matching imagesets and RN assets, so no asset additions are required.

https://claude.ai/code/session_01GHjUBALjswJqq17FNmHYus