### PR TITLE
🐛 - Fix EAS Update scheme validation

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -64,8 +64,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   orientation: "portrait",
   userInterfaceStyle: "automatic",
   icon: "./assets/icons/ios-icon-light.png",
-  // App URL scheme + the schemes the app responds to (widget://, liveActivity://)
-  scheme: ["betterrail", "widget", "liveActivity"],
+  // App URL scheme + the schemes the app responds to (widget://, liveactivity://)
+  // Note: schemes must be lowercase to pass EAS Update manifest validation.
+  scheme: ["betterrail", "widget", "liveactivity"],
   jsEngine: "hermes",
   assetBundlePatterns: ["**/*"],
 

--- a/src/hooks/use-deep-linking.ts
+++ b/src/hooks/use-deep-linking.ts
@@ -82,7 +82,7 @@ export function useDeepLinking(storeReady: boolean) {
       deepLinkWidgetURL(url)
       trackEvent("deep_link_widget")
     }
-    if (url.includes("liveActivity")) {
+    if (url.toLowerCase().includes("liveactivity")) {
       deepLinkLiveActivity(url)
       trackEvent("deep_link_live_activity")
     }

--- a/targets/widget/Live Activity/BetterRailLiveActivity.swift
+++ b/targets/widget/Live Activity/BetterRailLiveActivity.swift
@@ -11,7 +11,7 @@ struct BetterRailLiveActivity: Widget {
   func deepLinkURL(_ trainNumbers: [Int]) -> URL {
     // convert train numbers to be used as a URL parameter
     let urlParam = trainNumbers.map(String.init).joined(separator: ",")
-    return URL(string: "liveActivity://?trains=\(urlParam)")!
+    return URL(string: "liveactivity://?trains=\(urlParam)")!
   }
   
   var body: some WidgetConfiguration {


### PR DESCRIPTION
## Problem

`eas update` was failing with a manifest validation error:

```
Manifest Validation Error:
scheme:must be string
scheme/2:'scheme/2' must match pattern "^[a-z][a-z0-9+.-]*$"
scheme:must match exactly one schema in oneOf
```

EAS Update's manifest validator requires URL schemes to be lowercase (`^[a-z][a-z0-9+.-]*$`). Our `liveActivity` scheme (`scheme/2`) failed because of the uppercase `A`. This surfaced only on `eas update` — `eas build` and the OS treat schemes case-insensitively, so it never complained before.

## Changes

- **`app.config.ts`** — rename scheme `liveActivity` → `liveactivity` (the actual fix).
- **`BetterRailLiveActivity.swift`** — Live Activity deep-link URL now uses `liveactivity://` to match the registered scheme.
- **`use-deep-linking.ts`** — deep-link handler matches case-insensitively, so it correctly handles both old (already-installed) builds emitting `liveActivity://` and new builds emitting `liveactivity://`.

## Safety

The Swift change only takes effect in a new native build, but the current production binary still emits `liveActivity://`. Because the JS handler is now case-insensitive, this is safe to ship as an OTA update right now — both casings are handled.

https://claude.ai/code/session_015RHnt2t7dXS9c5PAqLNkgM