### PR TITLE
📊 - Enable EAS Observe expo-router integration

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,7 +14,7 @@ import notifee from "@notifee/react-native"
 import * as Sentry from "@sentry/react-native"
 import { enableScreens } from "react-native-screens"
 import { PostHogProvider } from "posthog-react-native"
-import { ObserveRoot, useObserve } from "expo-observe"
+import { Observe, ObserveRoot, useObserve } from "expo-observe"
 import { GestureHandlerRootView } from "react-native-gesture-handler"
 import { useIAP, initConnection, finishTransaction, getAvailablePurchases } from "react-native-iap"
 
@@ -35,6 +35,12 @@ import PushNotification from "react-native-push-notification"
 import "react-native-console-time-polyfill"
 
 enableScreens()
+
+// Enable per-route navigation metrics (cold/warm TTR, per-route TTI). Must run at
+// module scope before any screen mounts — it cannot be toggled at runtime.
+Observe.configure({
+  integrations: { "expo-router": true },
+})
 
 const TELEMETRY_DISABLED_STORAGE_KEY = "telemetry_disabled"
 

--- a/src/screens/route-list/route-list-screen.tsx
+++ b/src/screens/route-list/route-list-screen.tsx
@@ -9,6 +9,7 @@ import { useNetworkState } from "expo-network"
 import { useQuery } from "react-query"
 import { closestIndexTo } from "date-fns"
 import { useRouter, useLocalSearchParams } from "expo-router"
+import { useObserve } from "expo-observe"
 import { useNavigationParamsStore } from "@/models/navigation-params/navigation-params"
 import { useShallow } from "zustand/react/shallow"
 import { useTrainRoutesStore, useRoutePlanStore, useRideStore, useSettingsStore } from "@/models"
@@ -44,6 +45,7 @@ export function RouteListScreen() {
   const hideSlowTrains = useSettingsStore((s) => s.hideSlowTrains)
   const { showActionSheetWithOptions } = useActionSheet()
   const colorScheme = useColorScheme()
+  const { markInteractive } = useObserve()
 
   // Reference to the current real time for date limit calculations
   const currentRealTime = useMemo(() => new Date(), [])
@@ -274,6 +276,16 @@ export function RouteListScreen() {
       return !item.isMuchLonger
     })
   }, [routeData, hideSlowTrains])
+
+  // Signal EAS Observe per-route TTI once the route results have resolved — either
+  // routes are rendered, or we've reached a terminal not-found / error state.
+  useEffect(() => {
+    const hasResults = filteredRouteData.length > 0
+    const isTerminalEmpty = !trains.isLoading && (resultType === "not-found" || trains.status === "error")
+    if (hasResults || isTerminalEmpty) {
+      markInteractive()
+    }
+  }, [filteredRouteData.length, trains.isLoading, trains.status, resultType, markInteractive])
 
   // Set the initial scroll index, since the Israel Rail API ignores the supplied time and
   // returns a route list for the whole day.


### PR DESCRIPTION
Enables the EAS Observe expo-router integration for per-route navigation metrics.

- Add `Observe.configure({ integrations: { "expo-router": true } })` at module scope in the root layout — gives automatic per-route `cold_ttr`/`warm_ttr`.
- Call `markInteractive()` in the route list screen once results resolve, for per-route TTI.

https://claude.ai/code/session_015RHnt2t7dXS9c5PAqLNkgM