### PR TITLE
🔖 - Bump app version to v2.7.2

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -51,7 +51,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Better Rail",
   slug: "better-rail",
   owner: "better-rail",
-  version: "2.7.1",
+  version: "2.7.2",
   updates: {
     url: "https://u.expo.dev/b7819f45-8466-4c11-8628-3539099e6c78",
   },


### PR DESCRIPTION
Bumps the app version from `2.7.1` to `2.7.2`.

https://claude.ai/code/session_01KjTrkHhzo9M5BjNJipv6k5