### PR TITLE
🐛 - Fix repeated "no trains found" alert while on route list / details

### DIFF
--- a/src/models/train-routes/train-routes.ts
+++ b/src/models/train-routes/train-routes.ts
@@ -73,10 +73,12 @@ export const useTrainRoutesStore = create<TrainRoutesStore>((set, get) => ({
             time,
             result.map((result) => result.departureTime),
           )
-          const difference = differenceInMinutes(closestDateToNow, time)
-          if (Math.abs(difference) >= 90) {
-            // We found routes for the selected day but not at the requested hour.
-            resultType = "different-hour"
+          if (closestDateToNow) {
+            const difference = differenceInMinutes(closestDateToNow, time)
+            if (Math.abs(difference) >= 90) {
+              // We found routes for the selected day but not at the requested hour.
+              resultType = "different-hour"
+            }
           }
         }
 

--- a/src/models/train-routes/train-routes.ts
+++ b/src/models/train-routes/train-routes.ts
@@ -47,7 +47,7 @@ export const useTrainRoutesStore = create<TrainRoutesStore>((set, get) => ({
   },
 
   async getRoutes(originId, destinationId, time) {
-    set({ status: "pending", resultType: "normal" })
+    set({ status: "pending" })
 
     const routeApi = new RouteApi()
     let foundRoutes = false
@@ -63,11 +63,11 @@ export const useTrainRoutesStore = create<TrainRoutesStore>((set, get) => ({
 
       if (result.length > 0) {
         foundRoutes = true
-        set({ routes: result, status: "done" })
 
+        let resultType: ResultType = "normal"
         if (apiHitCount > 0) {
           // We found routes for a date different than the requested date.
-          set({ resultType: "different-date" })
+          resultType = "different-date"
         } else {
           const closestDateToNow = closestTo(
             time,
@@ -76,9 +76,13 @@ export const useTrainRoutesStore = create<TrainRoutesStore>((set, get) => ({
           const difference = differenceInMinutes(closestDateToNow, time)
           if (Math.abs(difference) >= 90) {
             // We found routes for the selected day but not at the requested hour.
-            set({ resultType: "different-hour" })
+            resultType = "different-hour"
           }
         }
+
+        // Set resultType once, atomically with the results — flipping it through "normal"
+        // mid-fetch remounts RouteListWarning and re-fires its alert on every background refetch.
+        set({ routes: result, status: "done", resultType })
 
         return result
       } else {

--- a/src/screens/route-list/route-list-screen.tsx
+++ b/src/screens/route-list/route-list-screen.tsx
@@ -222,10 +222,14 @@ export function RouteListScreen() {
         if (data && data.length > 0) {
           const firstRouteDate = new Date(data[0].trains[0].departureTime).toDateString()
           if (firstRouteDate !== currentDate.toDateString()) {
-            // Update the current date to match the actual date of the routes
-            setCurrentDate(new Date(firstRouteDate))
+            // Update the current date to match the actual date of the routes, keeping the
+            // originally requested time-of-day — resetting to midnight re-runs the query
+            // with 00:00 and triggers a spurious "different-hour" warning.
+            const updatedDate = new Date(firstRouteDate)
+            updatedDate.setHours(currentDate.getHours(), currentDate.getMinutes(), 0, 0)
+            setCurrentDate(updatedDate)
             // Update the next day date accordingly
-            const nextDate = new Date(firstRouteDate)
+            const nextDate = new Date(updatedDate)
             nextDate.setDate(nextDate.getDate() + 1)
             setNextDayDate(nextDate)
           }
@@ -533,7 +537,9 @@ export function RouteListScreen() {
         />
       )}
 
-      {resultType === "not-found" && !trains.isLoading && isInternetReachable && (
+      {/* A failed background refetch sets "not-found" in the store directly, bypassing the
+          onError guard — so also require that no results are currently displayed. */}
+      {resultType === "not-found" && !trains.isLoading && isInternetReachable && routeData.length === 0 && (
         <View style={{ marginTop: spacing[4] }}>
           <NoTrainsFoundMessage />
         </View>


### PR DESCRIPTION
## Problem
When a search lands in a warning state, the "No trains found…" alert re-fires every minute while sitting on the route list or route details screen — even though train results are visibly displayed in the list.

## Causes & fixes
1. **Repeating alert**: the route list query refetches every 60s, and `getRoutes` reset `resultType` to `"normal"` at the start of every call before setting it back to the warning type. The flip unmounted/remounted `RouteListWarning`, whose mount-only effect re-fired the Burnt alert (iOS) / modal (Android) each minute — showing over route details too, since the alert is a native overlay. **Fix**: `getRoutes` now sets the final `resultType` once, atomically with the results, so refetches with an unchanged outcome cause no state transition and the warning fires once per search.
2. **Spurious "different-hour" warning**: after a "different-date" result, the route list's `onSuccess` reset `currentDate` to *midnight* of the found date, changing the query key and re-querying for 00:00 — which reported "No trains found at the requested time" over perfectly valid results. **Fix**: preserve the originally requested time-of-day when updating `currentDate`.
3. **"Not found" message under a populated list**: `routeApi.getRoutes` swallows errors and returns `[]`, so a transient failure during a background refetch made the store set `resultType: "not-found"` directly, bypassing the screen's `onError` guard. **Fix**: only render `NoTrainsFoundMessage` when no results are displayed.

Also guards `closestTo` against `undefined` per review feedback (fixes a pre-existing strict-null TS error).