### PR TITLE
🐛 - Fix force update button stretching to fill screen on Android

### DIFF
--- a/src/screens/force-update/force-update-screen.tsx
+++ b/src/screens/force-update/force-update-screen.tsx
@@ -64,7 +64,10 @@ const styles = StyleSheet.create((theme, rt) => ({
     lineHeight: 24,
   },
   button: {
-    minWidth: "100%",
+    // Button's wrapper is flex: 1; without this it stretches to fill the screen on Android.
+    flex: 0,
+    width: "100%",
+    minHeight: 55,
   },
   buttonLiquidGlass: {
     minWidth: "100%",


### PR DESCRIPTION
The shared `Button` component's Android wrapper uses `flex: 1`, so on the force update screen (a `flex: 1` column) the button expanded to fill all remaining screen height, as reported by users on 2.6.x. This overrides the button's container style with `flex: 0`, `width: 100%`, and `minHeight: 55` so it renders as a normal full-width button. iOS is unaffected since the liquid-glass branch already has a fixed height.