### PR TITLE
🐛 - Fix repeated "active ride exists" alert loop when starting a new ride

### DIFF
--- a/src/screens/route-details/components/start-ride-button.tsx
+++ b/src/screens/route-details/components/start-ride-button.tsx
@@ -64,7 +64,11 @@ export function StartRideButton(props: StartRideButtonProps) {
   const isStartRideButtonDisabled = isRouteInFuture || isRouteInPast || areActivitiesDisabled()
 
   const startRide = async () => {
-    if (ride.id) {
+    // Read the id from the store rather than the render snapshot: after stopRide
+    // clears it, the recursive call below must see the fresh value or it will
+    // re-show this alert in a loop.
+    const activeRideId = useRideStore.getState().id
+    if (activeRideId) {
       return Alert.alert(translate("ride.rideExistsTitle"), translate("ride.rideExistsMessage"), [
         {
           style: "cancel",
@@ -73,7 +77,7 @@ export function StartRideButton(props: StartRideButtonProps) {
         {
           text: translate("ride.startNewRide"),
           onPress: async () => {
-            await ride.stopRide(ride.id)
+            await ride.stopRide(activeRideId)
             return startRide()
           },
         },


### PR DESCRIPTION
When a ride was already active and the user tapped **Start Ride** → **Start New Ride**, the "An active ride exists" alert kept reappearing in a loop until Cancel was pressed.

The handler checked `ride.id` from the component's render snapshot, so after `stopRide` cleared the store, the recursive `startRide()` call still saw the stale truthy id and re-showed the alert. The handler now reads the id fresh via `useRideStore.getState().id`, so after stopping the old ride the new one starts immediately.