### PR TITLE
🐛 - Fix double-encoded newlines in feedback email body on Android

### DIFF
--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -119,6 +119,7 @@
     "facebook": "فيسبوك",
     "twitter": "تويتر",
     "feedback": "ارسال الملاحظات",
+    "feedbackMailError": "تعذر فتح تطبيق البريد. يمكنكم مراسلتنا على feedback@better-rail.co.il",
     "imageAttribution": "كرديت الصور",
     "privacy": "خصوصية",
     "privacyPolicy": "سياسة الخصوصية",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -125,6 +125,7 @@
     "privacyPolicyLink": "https://better-rail.co.il/en/privacy-policy",
     "disableTelemetry": "Disable Telemetry",
     "feedback": "Send Feedback",
+    "feedbackMailError": "Could not open the mail app. You can reach us at feedback@better-rail.co.il",
     "languageChangeAlertTitle": "Language Change",
     "languageChangeAlertMessage": "The app will restart to apply the changes",
     "tipJar": "Tip Jar",

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -138,6 +138,7 @@
     "facebook": "פייסבוק",
     "twitter": "טוויטר",
     "feedback": "שליחת פידבק",
+    "feedbackMailError": "לא ניתן לפתוח את אפליקציית המייל. אפשר לכתוב לנו לכתובת feedback@better-rail.co.il",
     "imageAttribution": "קרדיט תמונות",
     "privacy": "פרטיות",
     "privacyPolicy": "מדיניות פרטיות",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -122,6 +122,7 @@
     "privacyPolicyLink": "https://better-rail.co.il/en/privacy-policy",
     "disableTelemetry": "Отключить телеметрию",
     "feedback": "Обратная связь",
+    "feedbackMailError": "Не удалось открыть почтовое приложение. Вы можете написать нам на feedback@better-rail.co.il",
     "languageChangeAlertTitle": "Смена языка",
     "languageChangeAlertMessage": "Приложение перезагрузится чтобы применить новые настройки",
     "aboutText": "Better Rail это приложение с открытым исходным кодом, целью которого является сделать расписания Израильских Железных Дорог более доступными для общественности.",

--- a/src/screens/settings/settings-about-screen.tsx
+++ b/src/screens/settings/settings-about-screen.tsx
@@ -23,6 +23,7 @@ App Locale: ${userLocale}
 Device Locale: ${deviceLocale}
 `,
   ios: "",
+  default: "",
 })
 
 export function AboutScreen() {
@@ -78,7 +79,9 @@ export function AboutScreen() {
               `mailto:feedback@better-rail.co.il?subject=${encodeURIComponent(
                 "פידבק על Better Rail",
               )}&body=${encodeURIComponent(emailBody)}`,
-            )
+            ).catch((error) => {
+              console.error("Failed to open mail client:", error)
+            })
           }
         />
       </View>

--- a/src/screens/settings/settings-about-screen.tsx
+++ b/src/screens/settings/settings-about-screen.tsx
@@ -16,8 +16,7 @@ const TWITTER_WEB_URL = "https://x.com/better_rail"
 
 // TODO: Add mail body to iOS - need to understand how to add newlines correctly
 const emailBody = Platform.select({
-  android: `%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A
----
+  android: `\n\n\n\n\n\n\n\n\n\n---
 App: Better Rail ${getVersion()} (${getBuildNumber()})
 Device: ${getDeviceId()} (${getSystemVersion()})
 App Locale: ${userLocale}
@@ -75,7 +74,11 @@ export function AboutScreen() {
           title={translate("settings.feedback")}
           icon="📨"
           onPress={() =>
-            Linking.openURL(encodeURI(`mailto:feedback@better-rail.co.il?subject=פידבק על Better Rail&body=${emailBody}`))
+            Linking.openURL(
+              `mailto:feedback@better-rail.co.il?subject=${encodeURIComponent(
+                "פידבק על Better Rail",
+              )}&body=${encodeURIComponent(emailBody)}`,
+            )
           }
         />
       </View>

--- a/src/screens/settings/settings-about-screen.tsx
+++ b/src/screens/settings/settings-about-screen.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Image, Linking, Platform, View } from "react-native"
+import { Alert, Image, Linking, Platform, View } from "react-native"
 import { StyleSheet } from "react-native-unistyles"
 import { Screen, Text } from "@/components"
 import { SettingBox } from "./components/settings-box"
@@ -79,8 +79,8 @@ export function AboutScreen() {
               `mailto:feedback@better-rail.co.il?subject=${encodeURIComponent(
                 "פידבק על Better Rail",
               )}&body=${encodeURIComponent(emailBody)}`,
-            ).catch((error) => {
-              console.error("Failed to open mail client:", error)
+            ).catch(() => {
+              Alert.alert(translate("settings.feedbackMailError"))
             })
           }
         />


### PR DESCRIPTION
The Android feedback email body was built with pre-encoded `%0D%0A` sequences and then the whole mailto URL was passed through `encodeURI`, which re-encoded the percent signs — so mail clients showed literal `%0D%0A` text instead of blank lines. The body template now uses plain newlines, and the subject and body are each encoded once with `encodeURIComponent`. iOS behavior is unchanged (empty body, per the existing TODO).