### PR TITLE
🐛 - Fix Android release build by giving the splash screen an image

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -161,19 +161,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         dark: {
           backgroundColor: "#1c1c1e",
         },
-        // Android 12+ always renders a splash icon, and expo-splash-screen's theme
-        // unconditionally points `windowSplashScreenAnimatedIcon` at
-        // @drawable/splashscreen_logo — a drawable it only generates when an `image`
-        // is set. Without one the release build fails linking that missing resource
-        // (`processReleaseResources`). Use the brand mark so the Android splash is
-        // intentional and the build links; a dark variant keeps the icon on-color in
-        // dark mode. (iOS stays color-only — its splash needs no image.)
         android: {
           image: "./assets/icons/android-foreground.png",
           imageWidth: 180,
-          dark: {
-            image: "./assets/icons/android-foreground.png",
-          },
         },
       },
     ],

--- a/app.config.ts
+++ b/app.config.ts
@@ -161,6 +161,20 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         dark: {
           backgroundColor: "#1c1c1e",
         },
+        // Android 12+ always renders a splash icon, and expo-splash-screen's theme
+        // unconditionally points `windowSplashScreenAnimatedIcon` at
+        // @drawable/splashscreen_logo — a drawable it only generates when an `image`
+        // is set. Without one the release build fails linking that missing resource
+        // (`processReleaseResources`). Use the brand mark so the Android splash is
+        // intentional and the build links; a dark variant keeps the icon on-color in
+        // dark mode. (iOS stays color-only — its splash needs no image.)
+        android: {
+          image: "./assets/icons/android-foreground.png",
+          imageWidth: 180,
+          dark: {
+            image: "./assets/icons/android-foreground.png",
+          },
+        },
       },
     ],
     [


### PR DESCRIPTION
The Android release build was failing at `:app:processReleaseResources` with `resource drawable/splashscreen_logo not found`. expo-splash-screen's generated theme always points `windowSplashScreenAnimatedIcon` at `@drawable/splashscreen_logo`, but only *generates* that drawable when an `image` is set — so configuring only `backgroundColor` left the release build unable to link the missing resource. This adds the brand mark (`android-foreground.png`, with a dark variant) as the Android splash `image`, which both fixes the build and gives an intentional splash icon (Android 12+ always renders one anyway). iOS is unchanged and stays color-only.