### PR TITLE
🐛 - Fix station not updating when changed from the route list header

### DIFF
--- a/src/components/route-details-header/route-details-header.tsx
+++ b/src/components/route-details-header/route-details-header.tsx
@@ -2,7 +2,7 @@ import { useRef, useEffect } from "react"
 import { Image, ImageBackground, View, Animated as RNAnimated, Pressable } from "react-native"
 import type { ViewStyle } from "react-native"
 import { StyleSheet } from "react-native-unistyles"
-import { useRouter } from "expo-router"
+import { useRouter, useNavigation } from "expo-router"
 import { trackEvent } from "@/services/analytics"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import LinearGradient from "react-native-linear-gradient"
@@ -53,6 +53,7 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
     switchDirection,
   } = useRoutePlanStore(useShallow((s) => ({ origin: s.origin, destination: s.destination, switchDirection: s.switchDirection })))
   const router = useRouter()
+  const navigation = useNavigation()
   const insets = useSafeAreaInsets()
   const routeEditDisabled = screenName !== "routeList"
 
@@ -123,10 +124,11 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
   }
 
   useEffect(() => {
-    router.setParams({
+    navigation.setParams({
       originId: routePlanOrigin.id,
       destinationId: routePlanDestination.id,
-    })
+    } as never)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routePlanOrigin.id, routePlanDestination.id])
 
   const renderHeaderRight = () => {

--- a/src/components/route-details-header/route-details-header.tsx
+++ b/src/components/route-details-header/route-details-header.tsx
@@ -124,12 +124,14 @@ export function RouteDetailsHeader(props: RouteDetailsHeaderProps) {
   }
 
   useEffect(() => {
-    navigation.setParams({
-      originId: routePlanOrigin.id,
-      destinationId: routePlanDestination.id,
-    } as never)
+    if (routePlanOrigin?.id && routePlanDestination?.id) {
+      navigation.setParams({
+        originId: routePlanOrigin.id,
+        destinationId: routePlanDestination.id,
+      } as never)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routePlanOrigin.id, routePlanDestination.id])
+  }, [routePlanOrigin?.id, routePlanDestination?.id])
 
   const renderHeaderRight = () => {
     if (screenName === "routeDetails") {


### PR DESCRIPTION
Picking a new origin/destination from the select-station modal wasn't updating the route list.

The header synced the route-plan store into the screen's route params using `router.setParams`, which targets the *currently focused* route — while the select-station modal is open, the update landed on the modal instead of the route list, so the query key never changed and no re-fetch happened. Switched to `navigation.setParams`, which is bound to this screen's own route (the route list) regardless of what's focused on top. This also fixes the swap-direction arrow, which used the same sync path.