### PR TITLE
🐛 Fix Live Activity tap always returning to the planner

### DIFF
--- a/app/+native-intent.tsx
+++ b/app/+native-intent.tsx
@@ -22,5 +22,5 @@ export function redirectSystemPath({ path }: { path: string; initial: boolean })
     // the default behavior on any unexpected input.
   }
 
-  return path
+  return path || null
 }

--- a/app/+native-intent.tsx
+++ b/app/+native-intent.tsx
@@ -1,0 +1,26 @@
+/**
+ * Expo Router's native deep-link handler, invoked for every incoming URL before
+ * the router navigates.
+ *
+ * The `widget://` and `liveactivity://` schemes are handled manually in
+ * `use-deep-linking.ts`, because resolving them requires app state (the active
+ * ride / route plan) rather than a static path. Since these schemes are also
+ * registered as app schemes, Expo Router's own linking otherwise tries to
+ * resolve the pathless URL, matches it to the index route, and resets the stack
+ * back to the planner — clobbering our manual navigation (and popping the active
+ * ride modal). Returning `null` tells Expo Router to skip navigation and stay on
+ * the current path, leaving these URLs entirely to our handler.
+ */
+export function redirectSystemPath({ path }: { path: string; initial: boolean }): string | null {
+  try {
+    const scheme = path.toLowerCase()
+    if (scheme.startsWith("widget://") || scheme.startsWith("liveactivity://")) {
+      return null
+    }
+  } catch {
+    // Never throw from here — it can crash the app on launch. Fall through to
+    // the default behavior on any unexpected input.
+  }
+
+  return path
+}

--- a/src/hooks/use-deep-linking.ts
+++ b/src/hooks/use-deep-linking.ts
@@ -6,7 +6,6 @@ import { donateRouteIntent, reloadAllTimelines } from "@/utils/ios-helpers"
 import { useRoutePlanStore } from "@/models/route-plan/route-plan"
 import { useRideStore } from "@/models/ride/ride"
 import { useNavigationParamsStore } from "@/models/navigation-params/navigation-params"
-import { isEqual } from "lodash"
 import { trackEvent } from "@/services/analytics"
 import { getStationById } from "@/data/stations"
 import Shortcuts, { ShortcutItem } from "react-native-quick-actions-shortcuts"
@@ -55,23 +54,14 @@ export function useDeepLinking(storeReady: boolean) {
       originId: String(originId),
       destinationId: String(destinationId),
     })
-    router.push("/active-ride")
+    // `navigate` (not `push`) so that if the active-ride modal is already open
+    // it stays intact instead of stacking a duplicate, and if it was dismissed —
+    // or another screen is showing — it reliably reopens.
+    router.navigate("/active-ride")
   }
 
-  function deepLinkLiveActivity(url: string) {
-    const currentRouteItem = useNavigationParamsStore.getState().routeItem
-
-    if (!currentRouteItem) {
-      openActiveRideScreen()
-    } else {
-      const { trains } = extractURLParams(url)
-      const activityTrainNumbers = trains.split(",").map((t) => parseInt(t))
-      const routeTrainNumbers = currentRouteItem.trains.map((t) => t.trainNumber)
-
-      if (!isEqual(activityTrainNumbers, routeTrainNumbers)) {
-        openActiveRideScreen()
-      }
-    }
+  function deepLinkLiveActivity() {
+    openActiveRideScreen()
   }
 
   function handleDeepLinkURL(url: string) {
@@ -81,7 +71,7 @@ export function useDeepLinking(storeReady: boolean) {
       trackEvent("deep_link_widget")
     }
     if (url.toLowerCase().includes("liveactivity")) {
-      deepLinkLiveActivity(url)
+      deepLinkLiveActivity()
       trackEvent("deep_link_live_activity")
     }
   }

--- a/src/hooks/use-deep-linking.ts
+++ b/src/hooks/use-deep-linking.ts
@@ -61,6 +61,7 @@ export function useDeepLinking(storeReady: boolean) {
   }
 
   function deepLinkLiveActivity() {
+    if (!storeReady) return
     openActiveRideScreen()
   }
 


### PR DESCRIPTION
Tapping an ongoing iOS Live Activity always dumped the user back on the planner: because `liveactivity://` (and `widget://`) are registered app schemes, Expo Router's own linking resolved the pathless URL to the index route and reset the stack, clobbering the manual navigation in `use-deep-linking.ts`. A new `app/+native-intent.tsx` returns `null` for these two schemes so Expo Router leaves them entirely to our handler. The Live Activity handler now always routes to `/active-ride` using `router.navigate` (instead of `push`), so the modal stays intact when already open and reliably reopens otherwise — replacing the fragile train-number heuristic that couldn't tell whether the modal was actually visible.