### PR TITLE
🐛 - Fix adding a train to the calendar after the expo-calendar legacy API removal

### DIFF
--- a/src/utils/helpers/calendar-helpers.ts
+++ b/src/utils/helpers/calendar-helpers.ts
@@ -1,4 +1,4 @@
-import { Alert, Linking } from "react-native"
+import { Alert, Linking, Platform } from "react-native"
 import * as Calendar from "expo-calendar"
 import { translate } from "@/i18n"
 import { trackEvent } from "@/services/analytics"
@@ -33,10 +33,25 @@ export function createEventConfig(routeItem: RouteItem): CalendarEventConfig {
   }
 }
 
+// getDefaultCalendarSync is iOS-only, so on Android we pick the primary (or any modifiable) calendar
+async function getEventCalendar(): Promise<Calendar.ExpoCalendar> {
+  if (Platform.OS === "ios") {
+    return Calendar.getDefaultCalendarSync()
+  }
+
+  const calendars = await Calendar.getCalendars()
+  const eventCalendar =
+    calendars.find((calendar) => calendar.isPrimary) ?? calendars.find((calendar) => calendar.allowsModifications)
+  if (!eventCalendar) {
+    throw new Error("No modifiable calendar found on device")
+  }
+  return eventCalendar
+}
+
 export async function addRouteToCalendar(routeItem: RouteItem): Promise<boolean> {
   trackEvent("add_route_to_calendar")
 
-  const { status } = await Calendar.requestCalendarPermissionsAsync()
+  const { status } = await Calendar.requestCalendarPermissions()
 
   if (status !== "granted") {
     Alert.alert(translate("routeDetails.noCalendarAccessTitle"), translate("routeDetails.noCalendarAccessMessage"), [
@@ -49,14 +64,15 @@ export async function addRouteToCalendar(routeItem: RouteItem): Promise<boolean>
   const eventConfig = createEventConfig(routeItem)
 
   try {
-    await Calendar.createEventInCalendarAsync({
+    const eventCalendar = await getEventCalendar()
+    const { action } = await eventCalendar.addEventWithForm({
       title: eventConfig.title,
       startDate: new Date(eventConfig.startDate),
       endDate: new Date(eventConfig.endDate),
       location: eventConfig.location,
       notes: eventConfig.notes,
     })
-    return true
+    return action !== "canceled"
   } catch (error) {
     console.error(error)
     if (error instanceof Error) {

--- a/src/utils/helpers/calendar-helpers.ts
+++ b/src/utils/helpers/calendar-helpers.ts
@@ -36,12 +36,17 @@ export function createEventConfig(routeItem: RouteItem): CalendarEventConfig {
 // getDefaultCalendarSync is iOS-only, so on Android we pick the primary (or any modifiable) calendar
 async function getEventCalendar(): Promise<Calendar.ExpoCalendar> {
   if (Platform.OS === "ios") {
-    return Calendar.getDefaultCalendarSync()
+    const defaultCalendar = Calendar.getDefaultCalendarSync()
+    if (!defaultCalendar) {
+      throw new Error("No default calendar found on device")
+    }
+    return defaultCalendar
   }
 
   const calendars = await Calendar.getCalendars()
   const eventCalendar =
-    calendars.find((calendar) => calendar.isPrimary) ?? calendars.find((calendar) => calendar.allowsModifications)
+    calendars.find((calendar) => calendar.isPrimary && calendar.allowsModifications) ??
+    calendars.find((calendar) => calendar.allowsModifications)
   if (!eventCalendar) {
     throw new Error("No modifiable calendar found on device")
   }


### PR DESCRIPTION
## Problem

Adding a train to the calendar has been broken since the Expo SDK 56 upgrade. expo-calendar 56 replaced its function API with an object-oriented one — the legacy functions are still exported, but now **throw at runtime**:

```
ERROR Uncaught (in promise) Error: Method requestCalendarPermissionsAsync
      imported from "expo-calendar" is deprecated.
```

`addRouteToCalendar` called two of them: `requestCalendarPermissionsAsync()` and `createEventInCalendarAsync()`.

## Fix

Migrate `calendar-helpers.ts` to the new API:

- `requestCalendarPermissionsAsync()` → `requestCalendarPermissions()`
- `createEventInCalendarAsync({...})` → `calendar.addEventWithForm({...})`, where the calendar is `getDefaultCalendarSync()` on iOS and the primary (or any modifiable) calendar from `getCalendars()` on Android, since `getDefaultCalendarSync` is iOS-only
- Bonus: return `false` when the user cancels the event form on iOS, so the "Added to calendar" toast no longer shows on cancel (Android always reports `done`, so behavior there is unchanged)

## Verification

Exercised end-to-end in the iOS simulator (dev client + Metro):

- ✅ Repro'd the runtime throw with the old code first
- ✅ With the fix, the system "New Event" form opens, populated with ride title, station location, departure/arrival times, and train-number notes
- ✅ Permission denied → existing localized "no calendar access" alert with Cancel/Settings
- ✅ Permission not-determined → iOS full-access prompt with our usage string (`NSCalendarsFullAccessUsageDescription`)
- ✅ `bun run compile`, `bun test` (14/14), oxlint/oxfmt all clean