### PR TITLE
🐛 - Add ascAppId to iOS submit profile to skip ASC app lookup

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -49,7 +49,8 @@
   "submit": {
     "production": {
       "ios": {
-        "appleTeamId": "UE6BVYPPFX"
+        "appleTeamId": "UE6BVYPPFX",
+        "ascAppId": "1562982976"
       }
     }
   }


### PR DESCRIPTION
Adds `ascAppId` (`1562982976`) to the iOS production submit profile in `eas.json`. This skips the "Ensuring your app exists on App Store Connect" round-trip that `eas submit` otherwise runs before every submission, which can hang or fail. Subsequent submissions go straight to uploading.