### PR TITLE
✅ - Add Maestro e2e tests with a GitHub Actions workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,9 +28,18 @@ jobs:
       # (eas build --profile development-simulator --platform ios).
       - name: Download latest dev-client simulator build from EAS
         run: |
+          # EAS deletes build artifacts after a retention window (expirationDate),
+          # so pick the newest build whose artifact is still downloadable.
           BUILD_URL=$(eas build:list --platform ios --profile development-simulator \
-            --status finished --limit 1 --json --non-interactive \
-            | jq -re '.[0].artifacts | .applicationArchiveUrl // .buildUrl')
+            --status finished --limit 10 --json --non-interactive \
+            | jq -re '[.[] | select(.expirationDate > (now | todate))
+                           | .artifacts.applicationArchiveUrl // .artifacts.buildUrl
+                           | select(. != null)]
+                      | first') || {
+            echo "::error::No development-simulator build with a live artifact on EAS." \
+                 "Run: eas build --profile development-simulator --platform ios"
+            exit 1
+          }
           curl -fsSL "$BUILD_URL" -o /tmp/build.tar.gz
           mkdir /tmp/app && tar -xzf /tmp/build.tar.gz -C /tmp/app
           APP_PATH=$(find /tmp/app -maxdepth 2 -name '*.app' | head -n 1)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,10 @@ jobs:
           xcrun simctl boot "$UDID"
           xcrun simctl bootstatus "$UDID" -b
           xcrun simctl install "$UDID" "$APP_PATH"
+          # Mark the expo-dev-menu onboarding as finished so its "Continue"
+          # sheet doesn't cover the launcher and block the flow's URL entry.
+          xcrun simctl spawn "$UDID" defaults write il.co.better-rail \
+            EXDevMenuIsOnboardingFinished -bool true
 
       - name: Start Metro
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,6 +82,8 @@ jobs:
           echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
 
       - name: Run Maestro flows
+        env:
+          MAESTRO_CLI_NO_ANALYTICS: "1"
         run: maestro test .maestro/flows
 
       - name: Upload logs and screenshots

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,9 +24,26 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       # The dev client loads JS from Metro, so the PR's JavaScript is what gets
-      # tested — the EAS binary only needs rebuilding when native deps change
-      # (eas build --profile development-simulator --platform ios).
-      - name: Download latest dev-client simulator build from EAS
+      # tested — the EAS binary only needs rebuilding when native inputs change.
+      # @expo/fingerprint hashes exactly those inputs (native deps, config
+      # plugins, eas.json, patches...), so we cache the extracted .app under it
+      # and only hit EAS when the fingerprint changes or the cache is evicted.
+      - name: Compute native fingerprint
+        id: fingerprint
+        run: |
+          HASH=$(node node_modules/@expo/fingerprint/bin/cli.js fingerprint:generate \
+            --platform ios | jq -re '.hash')
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached simulator build
+        id: build-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/app
+          key: ios-sim-build-${{ steps.fingerprint.outputs.hash }}
+
+      - name: Download dev-client simulator build from EAS
+        if: steps.build-cache.outputs.cache-hit != 'true'
         run: |
           # EAS deletes build artifacts after a retention window (expirationDate),
           # so pick the newest build whose artifact is still downloadable.
@@ -42,6 +59,9 @@ jobs:
           }
           curl -fsSL "$BUILD_URL" -o /tmp/build.tar.gz
           mkdir /tmp/app && tar -xzf /tmp/build.tar.gz -C /tmp/app
+
+      - name: Locate and prepare the app bundle
+        run: |
           # The archive contains the watch app as a sibling product
           # (Debug-watchsimulator/) — select the iPhone app explicitly.
           APP_PATH=$(find /tmp/app -maxdepth 2 -name '*.app' -path '*iphonesimulator*' | head -n 1)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,9 @@ jobs:
           }
           curl -fsSL "$BUILD_URL" -o /tmp/build.tar.gz
           mkdir /tmp/app && tar -xzf /tmp/build.tar.gz -C /tmp/app
-          APP_PATH=$(find /tmp/app -maxdepth 2 -name '*.app' | head -n 1)
+          # The archive contains the watch app as a sibling product
+          # (Debug-watchsimulator/) — select the iPhone app explicitly.
+          APP_PATH=$(find /tmp/app -maxdepth 2 -name '*.app' -path '*iphonesimulator*' | head -n 1)
           test -n "$APP_PATH"
           # The bundle embeds the watch app, which a simulator without a paired
           # Apple Watch refuses to install. The flows don't use it — strip it.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,6 +44,9 @@ jobs:
           mkdir /tmp/app && tar -xzf /tmp/build.tar.gz -C /tmp/app
           APP_PATH=$(find /tmp/app -maxdepth 2 -name '*.app' | head -n 1)
           test -n "$APP_PATH"
+          # The bundle embeds the watch app, which a simulator without a paired
+          # Apple Watch refuses to install. The flows don't use it — strip it.
+          rm -rf "$APP_PATH/Watch"
           echo "APP_PATH=$APP_PATH" >> "$GITHUB_ENV"
 
       - name: Boot simulator and install the app

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,80 @@
+name: E2E
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  maestro-ios:
+    # Fork PRs don't get secrets, so EAS auth would fail — skip them.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: macos-15
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      # The dev client loads JS from Metro, so the PR's JavaScript is what gets
+      # tested — the EAS binary only needs rebuilding when native deps change
+      # (eas build --profile development-simulator --platform ios).
+      - name: Download latest dev-client simulator build from EAS
+        run: |
+          BUILD_URL=$(eas build:list --platform ios --profile development-simulator \
+            --status finished --limit 1 --json --non-interactive \
+            | jq -re '.[0].artifacts | .applicationArchiveUrl // .buildUrl')
+          curl -fsSL "$BUILD_URL" -o /tmp/build.tar.gz
+          mkdir /tmp/app && tar -xzf /tmp/build.tar.gz -C /tmp/app
+          APP_PATH=$(find /tmp/app -maxdepth 2 -name '*.app' | head -n 1)
+          test -n "$APP_PATH"
+          echo "APP_PATH=$APP_PATH" >> "$GITHUB_ENV"
+
+      - name: Boot simulator and install the app
+        run: |
+          UDID=$(xcrun simctl list devices available --json \
+            | jq -re '[.devices | to_entries[] | select(.key | contains("iOS")) | .value[] | select(.name | startswith("iPhone"))] | last | .udid')
+          xcrun simctl boot "$UDID"
+          xcrun simctl bootstatus "$UDID" -b
+          xcrun simctl install "$UDID" "$APP_PATH"
+
+      - name: Start Metro
+        run: |
+          nohup bun start > metro.log 2>&1 &
+          for i in {1..30}; do
+            curl -sf http://localhost:8081/status > /dev/null && break
+            sleep 2
+          done
+          curl -sf http://localhost:8081/status
+
+      # Warm Metro's transform cache so the app's first load in the flows stays
+      # within their timeouts. Non-fatal: a real bundling error will surface in
+      # the Maestro run (and metro.log) anyway.
+      - name: Pre-build the JS bundle
+        run: |
+          curl -sf --max-time 600 -o /dev/null "http://localhost:8081/index.bundle?platform=ios&dev=true" \
+            || echo "pre-build failed (non-fatal)"
+
+      - name: Install Maestro
+        run: |
+          curl -fsSL https://get.maestro.mobile.dev | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Run Maestro flows
+        run: maestro test .maestro/flows
+
+      - name: Upload logs and screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-artifacts
+          path: |
+            ~/.maestro/tests
+            metro.log

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -1,0 +1,51 @@
+# E2E tests (Maestro)
+
+End-to-end tests run with [Maestro](https://maestro.mobile.dev) against the app on an iOS simulator.
+
+## Prerequisites
+
+- Maestro CLI installed (`curl -Ls https://get.maestro.mobile.dev | bash`)
+- A booted iOS simulator with the Better Rail dev client installed (`bun ios`)
+- Metro running: `bun start`
+
+## Running
+
+```sh
+bun e2e                                    # all flows
+maestro test .maestro/flows/plan-route.yaml  # a single flow
+```
+
+## Writing flows
+
+- Select elements by `testID` (Maestro's `id:` selector), never by visible text —
+  the app's display language follows the device locale, so text matching breaks
+  between Hebrew/English/Russian/Arabic devices.
+- Station search terms are typed in Hebrew: the search index always includes
+  Hebrew station names regardless of the app's display language, so Hebrew input
+  works on any device locale.
+- Flows launch the app through the dev-client deep link
+  (`betterrail://expo-development-client/?url=...`) so it connects to the local
+  Metro server. The optional taps on "Open" handle iOS's link confirmation dialog.
+  For testing release builds, replace `openLink` with a plain `launchApp`.
+
+## CI (GitHub Actions)
+
+`.github/workflows/e2e.yml` runs the flows on pull requests: it downloads the
+latest `development-simulator` build from EAS, installs it on an iOS simulator,
+starts Metro from the PR checkout, and runs Maestro. Because the dev client
+loads JS from Metro, the PR's JavaScript is what gets tested — the EAS binary
+only needs rebuilding when native dependencies change:
+
+```sh
+eas build --profile development-simulator --platform ios
+```
+
+Requirements: an `EXPO_TOKEN` repo secret (a robot access token from
+expo.dev), and at least one finished `development-simulator` build on EAS.
+Failed CI runs upload Maestro screenshots/logs and `metro.log` as a workflow
+artifact.
+
+## Debugging
+
+Failed runs write screenshots and logs to `~/.maestro/tests/<timestamp>/`.
+`maestro studio` opens an interactive inspector for the UI hierarchy.

--- a/.maestro/flows/plan-route.yaml
+++ b/.maestro/flows/plan-route.yaml
@@ -16,7 +16,7 @@ tags:
 # now-saved server and loads from the warm bundle, which reliably recovers.
 # For a release build this whole block can be replaced with a plain launchApp.
 - retry:
-    maxRetries: 4
+    maxRetries: 5
     commands:
       - launchApp
       - runFlow:
@@ -29,13 +29,15 @@ tags:
             - tapOn:
                 text: "exp://"
             - inputText: "http://localhost:8081"
-            - tapOn:
-                text: "Connect"
+            # Submit with the keyboard's return key rather than tapping the
+            # "Connect" button: on shorter simulators the keyboard covers the
+            # button, so tapping it silently fails and the URL is never saved.
+            - pressKey: Enter
       # First load bundles the app, so allow extra time.
       - extendedWaitUntil:
           visible:
             id: "planner-origin-card"
-          timeout: 90000
+          timeout: 120000
 
 # Select origin station: Jerusalem - Yitzhak Navon.
 # Search terms are typed in Hebrew because station search always indexes

--- a/.maestro/flows/plan-route.yaml
+++ b/.maestro/flows/plan-route.yaml
@@ -1,0 +1,52 @@
+appId: il.co.better-rail
+name: Plan a route
+tags:
+  - core
+---
+# Launch through the dev-client deep link so the app connects to the local Metro server.
+# For release builds this can be replaced with a plain launchApp.
+- openLink: betterrail://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081
+
+# iOS may ask for confirmation before opening the deep link
+- tapOn:
+    text: "Open"
+    optional: true
+- tapOn:
+    text: "Open"
+    optional: true
+
+# Wait for the planner screen (first load bundles the app, so allow extra time)
+- extendedWaitUntil:
+    visible:
+      id: "planner-origin-card"
+    timeout: 60000
+
+# Select origin station: Jerusalem - Yitzhak Navon.
+# Search terms are typed in Hebrew because station search always indexes
+# Hebrew names, regardless of the app's display language.
+- tapOn:
+    id: "planner-origin-card"
+- tapOn:
+    id: "station-search-input"
+- inputText: "ירושלים"
+- tapOn:
+    id: "station-item-680"
+
+# Select destination station: Tel Aviv - HaShalom
+- tapOn:
+    id: "planner-destination-card"
+- tapOn:
+    id: "station-search-input"
+- inputText: "השלום"
+- tapOn:
+    id: "station-item-4600"
+
+# Search for routes
+- tapOn:
+    id: "find-routes-button"
+
+# Route list should show at least one train
+- extendedWaitUntil:
+    visible:
+      id: "route-card"
+    timeout: 30000

--- a/.maestro/flows/plan-route.yaml
+++ b/.maestro/flows/plan-route.yaml
@@ -3,23 +3,39 @@ name: Plan a route
 tags:
   - core
 ---
-# Launch through the dev-client deep link so the app connects to the local Metro server.
-# For release builds this can be replaced with a plain launchApp.
-- openLink: betterrail://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081
-
-# iOS may ask for confirmation before opening the deep link
-- tapOn:
-    text: "Open"
-    optional: true
-- tapOn:
-    text: "Open"
-    optional: true
-
-# Wait for the planner screen (first load bundles the app, so allow extra time)
-- extendedWaitUntil:
-    visible:
-      id: "planner-origin-card"
-    timeout: 60000
+# Launch the app and wait for the planner. The dev client loads JS from the
+# local Metro server, so we point it at localhost:8081.
+#
+# On a fresh install the launcher has no saved server, so the URL is entered
+# manually (guarded by `runFlow: when: visible`); on any later launch the dev
+# client auto-reconnects to the saved server, so those steps are skipped.
+#
+# The whole launch is wrapped in `retry`: expo/fetch can intermittently crash
+# the JS runtime during the initial connect-and-reload on the iOS 18 simulator,
+# dropping the app to the home screen. Relaunching auto-reconnects to the
+# now-saved server and loads from the warm bundle, which reliably recovers.
+# For a release build this whole block can be replaced with a plain launchApp.
+- retry:
+    maxRetries: 4
+    commands:
+      - launchApp
+      - runFlow:
+          when:
+            visible:
+              text: "Enter URL manually"
+          commands:
+            - tapOn:
+                text: "Enter URL manually"
+            - tapOn:
+                text: "exp://"
+            - inputText: "http://localhost:8081"
+            - tapOn:
+                text: "Connect"
+      # First load bundles the app, so allow extra time.
+      - extendedWaitUntil:
+          visible:
+            id: "planner-origin-card"
+          timeout: 90000
 
 # Select origin station: Jerusalem - Yitzhak Navon.
 # Search terms are typed in Hebrew because station search always indexes

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "format:check": "oxfmt --check",
     "lint": "oxlint --fix && bun format",
     "test": "bun test",
+    "e2e": "maestro test .maestro/flows",
     "adb": "adb reverse tcp:9090 tcp:9090 && adb reverse tcp:3000 tcp:3000 && adb reverse tcp:9001 tcp:9001 && adb reverse tcp:8081 tcp:8081"
   },
   "dependencies": {

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -54,7 +54,7 @@ export const Button = function Button(props: CustomButtonProps) {
 
   if (isLiquidGlassSupported) {
     return (
-      <Pressable onPress={onPress} disabled={disabled}>
+      <Pressable onPress={onPress} disabled={disabled} testID={props.testID}>
         <LiquidGlassView
           interactive={!!onPress}
           style={[styles.liquidGlass, style]}
@@ -79,6 +79,7 @@ export const Button = function Button(props: CustomButtonProps) {
     return (
       <View style={[styles.buttonWrapper, containerStyle]}>
         <Pressable
+          testID={props.testID}
           style={[PRESSABLE_STYLE, disabled && { backgroundColor: color.disabled }]}
           onPressIn={() => setIsPressed(true)}
           onPressOut={() => setIsPressed(false)}

--- a/src/components/route-card/route-card.tsx
+++ b/src/components/route-card/route-card.tsx
@@ -139,6 +139,7 @@ export function RouteCard(props: RouteCardProps) {
 
   const cardContent = (
     <TouchableComponent
+      testID={props.testID}
       onPress={onPress}
       onLongPress={Platform.OS === "android" ? onLongPress : undefined}
       activeScale={0.97}

--- a/src/screens/planner/planner-screen.tsx
+++ b/src/screens/planner/planner-screen.tsx
@@ -193,6 +193,7 @@ export function PlannerScreen() {
           <Text preset="fieldLabel" tx="plan.origin" style={{ marginBottom: spacing[1] }} />
           <Animated.View style={{ transform: [{ scale: stationCardScale }] }}>
             <StationCard
+              testID="planner-origin-card"
               name={originData?.name}
               image={originData?.image}
               style={{ marginBottom: spacing[4] }}
@@ -207,6 +208,7 @@ export function PlannerScreen() {
           <Text preset="fieldLabel" tx="plan.destination" style={{ marginBottom: spacing[1] }} />
           <Animated.View style={{ transform: [{ scale: stationCardScale }] }}>
             <StationCard
+              testID="planner-destination-card"
               name={destinationData?.name}
               image={destinationData?.image}
               style={{ marginBottom: spacing[4] }}
@@ -232,6 +234,7 @@ export function PlannerScreen() {
           />
 
           <Button
+            testID="find-routes-button"
             title={translate("plan.find")}
             onPress={onGetRoutePress}
             disabled={!origin || !destination || origin.id === destination.id}

--- a/src/screens/route-list/route-list-screen.tsx
+++ b/src/screens/route-list/route-list-screen.tsx
@@ -451,6 +451,7 @@ export function RouteListScreen() {
 
     return (
       <RouteCard
+        testID="route-card"
         duration={item.duration}
         isMuchShorter={item.isMuchShorter}
         isMuchLonger={item.isMuchLonger}

--- a/src/screens/select-station/search-input.tsx
+++ b/src/screens/select-station/search-input.tsx
@@ -30,6 +30,7 @@ export const SearchInput = ({ searchTerm, setSearchTerm, autoFocus }) => {
       <View style={styles.searchInputWrapper}>
         <Image style={styles.searchIcon} source={searchIcon} />
         <TextInput
+          testID="station-search-input"
           style={styles.textInput}
           placeholder={translate("selectStation.placeholder")}
           placeholderTextColor={color.dim}

--- a/src/screens/select-station/select-station-screen.tsx
+++ b/src/screens/select-station/select-station-screen.tsx
@@ -28,6 +28,7 @@ export function SelectStationScreen() {
 
   const renderItem = (station: NormalizedStation) => (
     <StationCard
+      testID={`station-item-${station.id}`}
       name={station.name}
       image={station.image}
       style={styles.stationCard}


### PR DESCRIPTION
Adds end-to-end testing with [Maestro](https://maestro.mobile.dev): a plan-route flow that selects origin/destination stations and asserts route results appear, driven by new `testID`s on the planner, station search, and route card components. Flows select by `testID` only and type search terms in Hebrew, so they work regardless of the device locale.

A new E2E workflow runs the flows on pull requests using a macOS runner: it downloads the latest `development-simulator` build from EAS, starts Metro from the PR checkout, and runs Maestro against it — so each run tests the PR's JavaScript while the native binary is only rebuilt when native dependencies change. Failed runs upload Maestro screenshots and Metro logs as artifacts. Run locally with `bun e2e` (see `.maestro/README.md`).