### PR TITLE
💄 - Move "new" badge next to header icons

### DIFF
--- a/src/screens/planner/planner-screen-header.tsx
+++ b/src/screens/planner/planner-screen-header.tsx
@@ -123,13 +123,6 @@ export function PlannerScreenHeader() {
             </Chip>
           )}
 
-          {displayNewBadge && !showUrgentBar && (
-            <Chip variant="primary" onPress={() => router.push("/live-announcement")}>
-              <Image source={SPARKLES_ICON} style={{ height: 16, width: 16, marginEnd: spacing[2], tintColor: "white" }} />
-              <Text style={{ color: "white", fontWeight: "500", marginVertical: spacing[1] }} tx="common.new" />
-            </Chip>
-          )}
-
           {showZollyButton && !showUrgentBar && (
             <Chip
               variant="success"
@@ -154,6 +147,12 @@ export function PlannerScreenHeader() {
             </Chip>
           )}
         </View>
+        {displayNewBadge && !showUrgentBar && (
+          <Chip variant="primary" onPress={() => router.push("/live-announcement")}>
+            <Image source={SPARKLES_ICON} style={{ height: 16, width: 16, marginEnd: spacing[2], tintColor: "white" }} />
+            <Text style={{ color: "white", fontWeight: "500", marginVertical: spacing[1] }} tx="common.new" />
+          </Chip>
+        )}
         <TouchableOpacity onPress={openAnnouncements} activeOpacity={0.8} accessibilityLabel={translate("routes.updates")}>
           <Image source={UPDATES_ICON} style={[styles.headerIconImage]} />
         </TouchableOpacity>

--- a/src/screens/planner/planner-screen-header.tsx
+++ b/src/screens/planner/planner-screen-header.tsx
@@ -148,7 +148,7 @@ export function PlannerScreenHeader() {
           )}
         </View>
         {displayNewBadge && !showUrgentBar && (
-          <Chip variant="primary" onPress={() => router.push("/live-announcement")}>
+          <Chip variant="primary" style={{ marginStart: spacing[2] }} onPress={() => router.push("/live-announcement")}>
             <Image source={SPARKLES_ICON} style={{ height: 16, width: 16, marginEnd: spacing[2], tintColor: "white" }} />
             <Text style={{ color: "white", fontWeight: "500", marginVertical: spacing[1] }} tx="common.new" />
           </Chip>


### PR DESCRIPTION
Moves the "חדש" (new) announcement badge out of the left-aligned chips container and places it directly next to the settings/updates icons in the planner header. Because the header is an RTL row pinned with `justifyContent: "flex-end"`, the badge now renders adjacent to the icon cluster instead of on the opposite side. Visibility (`!showUrgentBar`) and tap behavior (`/live-announcement`) are unchanged.