### PR TITLE
🙈 - Hide planner "new" badge behind a disabled flag

### DIFF
--- a/src/screens/planner/planner-screen-header.tsx
+++ b/src/screens/planner/planner-screen-header.tsx
@@ -22,6 +22,7 @@ const SPARKLES_ICON = require("../../../assets/sparkles.png")
 const UPDATES_ICON = require("../../../assets/updates.png")
 const SETTINGS_ICON = require("../../../assets/settings.png")
 const ZOLLY_LOGO = require("../../../assets/zolly-announcement/zolly.png")
+const SHOW_NEW_BADGE = false
 
 export function PlannerScreenHeader() {
   const { origin, destination } = useRoutePlanStore(useShallow((s) => ({ origin: s.origin, destination: s.destination })))
@@ -147,7 +148,7 @@ export function PlannerScreenHeader() {
             </Chip>
           )}
         </View>
-        {displayNewBadge && !showUrgentBar && (
+        {SHOW_NEW_BADGE && displayNewBadge && !showUrgentBar && (
           <Chip variant="primary" style={{ marginStart: spacing[2] }} onPress={() => router.push("/live-announcement")}>
             <Image source={SPARKLES_ICON} style={{ height: 16, width: 16, marginEnd: spacing[2], tintColor: "white" }} />
             <Text style={{ color: "white", fontWeight: "500", marginVertical: spacing[1] }} tx="common.new" />


### PR DESCRIPTION
Hides the "new" announcement badge in the planner header by gating it behind a `SHOW_NEW_BADGE` flag that is currently set to `false`. The badge markup and its `displayNewBadge`/`showUrgentBar` conditions are preserved so it can be re-enabled by flipping the flag.