### PR TITLE
fix: dismiss live announcement to home instead of dismissAll

### DIFF
--- a/src/screens/live-announcement/support-us-announcement-screen.android.tsx
+++ b/src/screens/live-announcement/support-us-announcement-screen.android.tsx
@@ -16,7 +16,7 @@ export function SupportUsScreen() {
 
   const finish = () => {
     storage.save("seenLiveAnnouncement", new Date().toISOString())
-    router.dismissAll()
+    router.dismissTo("/")
   }
 
   return (

--- a/src/screens/live-announcement/support-us-announcement-screen.ios.tsx
+++ b/src/screens/live-announcement/support-us-announcement-screen.ios.tsx
@@ -19,7 +19,7 @@ export function SupportUsScreen() {
 
   const finish = () => {
     storage.save("seenLiveAnnouncement", new Date().toISOString())
-    router.dismissAll()
+    router.dismissTo("/")
   }
 
   return (


### PR DESCRIPTION
The live announcement onboarding screen called `router.dismissAll()` on finish/dismiss, which could tear down the entire navigation stack. This replaces it with `router.dismissTo("/")` on both iOS and Android so finishing the announcement returns the user to the home screen reliably.