### PR TITLE
chore: bump version to 2.7.4

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -51,7 +51,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Better Rail",
   slug: "better-rail",
   owner: "better-rail",
-  version: "2.7.3",
+  version: "2.7.4",
   updates: {
     url: "https://u.expo.dev/b7819f45-8466-4c11-8628-3539099e6c78",
   },


### PR DESCRIPTION
Bumps the app version from 2.7.3 to 2.7.4 in `app.config.ts`.