### PR TITLE
fix: display Apple Watch app as "Better Rail" on launcher

### DIFF
--- a/targets/watch/Info.plist
+++ b/targets/watch/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>Better Rail</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
The watchOS companion app was showing its product name (`BetterRailWatch`) on the Apple Watch launcher because it was the only target missing a `CFBundleDisplayName`, so the label fell back to `CFBundleName`/`PRODUCT_NAME`.

This adds `CFBundleDisplayName = "Better Rail"` to `targets/watch/Info.plist`, matching how the sibling widget/intent targets set their display name. The Xcode target `name` is left untouched so the product name stays space-free while only the user-visible launcher label changes.