### PR TITLE
fix: stop reporting expected "no routes found" errors to Sentry

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,7 +19,7 @@ import { useIAP, initConnection, finishTransaction, getAvailablePurchases } from
 
 import { initFonts } from "@/theme/fonts"
 import * as storage from "@/utils/storage"
-import { setupRootStore } from "@/models"
+import { setupRootStore, RoutesNotFoundError } from "@/models"
 import { useRideStore } from "@/models/ride/ride"
 import { useFavoritesStore } from "@/models/favorites/favorites"
 import { setInitialLanguage, setUserLanguage } from "@/i18n/i18n"
@@ -70,6 +70,11 @@ export const ErrorBoundary = Sentry.wrapExpoRouterErrorBoundary(ExpoErrorBoundar
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
     onError: (error, query) => {
+      // "No routes found" is an expected, app-handled outcome (offline or genuinely no
+      // trains for the date). It's thrown only to drive react-query's onError, so skip
+      // reporting it — it otherwise floods Sentry with tens of thousands of noise events.
+      if (error instanceof RoutesNotFoundError) return
+
       Sentry.captureException(error, {
         tags: { source: "react-query" },
         extra: { queryKey: query.queryKey },

--- a/src/models/train-routes/train-routes.ts
+++ b/src/models/train-routes/train-routes.ts
@@ -7,6 +7,21 @@ import { formatDateForAPI } from "@/utils/helpers/date-helpers"
 export type StatusType = "idle" | "pending" | "done" | "error"
 export type ResultType = "normal" | "different-date" | "different-hour" | "not-found"
 
+/**
+ * Thrown by `getRoutes` when no routes are found for the requested date (an expected,
+ * app-handled outcome — the UI shows a "no trains" / "no internet" state). It is used
+ * only to drive react-query's `onError`, so it is filtered out of Sentry reporting to
+ * avoid flooding the dashboard with tens of thousands of non-actionable events.
+ */
+export class RoutesNotFoundError extends Error {
+  constructor() {
+    super("Not found")
+    this.name = "RoutesNotFoundError"
+    // Restore the prototype chain so `instanceof` holds after transpilation to older targets.
+    Object.setPrototypeOf(this, RoutesNotFoundError.prototype)
+  }
+}
+
 export interface TrainRoutesState {
   routes: RouteItem[]
   resultType: ResultType
@@ -94,7 +109,7 @@ export const useTrainRoutesStore = create<TrainRoutesStore>((set, get) => ({
     }
     // We couldn't find routes for the requested date.
     set({ resultType: "not-found", status: "done" })
-    throw new Error("Not found")
+    throw new RoutesNotFoundError()
   },
 }))
 


### PR DESCRIPTION
## Problem

**BETTER-RAIL-Z** was Sentry's top noise issue: **34,418 events across 3,603 users** (`Error: Not found` from `getRoutes`). The breadcrumbs show nearly every occurrence is preceded by `AxiosError: Network Error` (`ERR_NETWORK`, status 0) hitting the rail API — the user is simply offline or the API is unreachable.

The flow producing the spam:
1. `route-api.ts` swallows all errors (including network failures) and returns `[]`.
2. `train-routes.ts` `getRoutes` treats empty as "no routes", retries up to 4 days, then `throw new Error("Not found")`.
3. The global `queryCache.onError` in `app/_layout.tsx` blindly reported every thrown error to Sentry.

But `"Not found"` isn't a bug — it's **expected, app-handled control flow**. The UI already renders the correct state for it (a "no-internet" error when offline, a "no trains" warning otherwise). The throw exists only to drive react-query's `onError`, so it should never have been reported.

## Fix

- **`src/models/train-routes/train-routes.ts`** — add a dedicated `RoutesNotFoundError` (exported via the `@/models` barrel) and throw it instead of a generic `Error`, with `Object.setPrototypeOf` so `instanceof` survives transpilation.
- **`app/_layout.tsx`** — the react-query `onError` handler early-returns for `RoutesNotFoundError` instead of capturing it. Genuine errors still reach Sentry; this expected outcome no longer does.

No user-facing behavior change — react-query still treats it as an error and all existing "no trains" / "no internet" UI keeps working.

The Sentry issue has been marked **resolved in the next release**.

https://claude.ai/code/session_018BZVLcsG4wnUqatWrJeEis