### PR TITLE
fix: Android crash from view recycling during screen transitions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -105,6 +105,7 @@
   },
   "patchedDependencies": {
     "react-native-quick-actions-shortcuts@1.0.2": "patches/react-native-quick-actions-shortcuts@1.0.2.patch",
+    "react-native-screens@4.25.2": "patches/react-native-screens@4.25.2.patch",
     "react-native-watch-connectivity@1.1.0": "patches/react-native-watch-connectivity@1.1.0.patch",
     "react-native-prompt-android@1.1.0": "patches/react-native-prompt-android@1.1.0.patch",
     "react-native-push-notification@8.1.1": "patches/react-native-push-notification@8.1.1.patch",

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "react-native-modal-datetime-picker@18.0.0": "patches/react-native-modal-datetime-picker@18.0.0.patch",
     "react-native-watch-connectivity@1.1.0": "patches/react-native-watch-connectivity@1.1.0.patch",
     "react-native-push-notification@8.1.1": "patches/react-native-push-notification@8.1.1.patch",
-    "react-native-prompt-android@1.1.0": "patches/react-native-prompt-android@1.1.0.patch"
+    "react-native-prompt-android@1.1.0": "patches/react-native-prompt-android@1.1.0.patch",
+    "react-native-screens@4.25.2": "patches/react-native-screens@4.25.2.patch"
   }
 }

--- a/patches/react-native-screens@4.25.2.patch
+++ b/patches/react-native-screens@4.25.2.patch
@@ -1,0 +1,95 @@
+diff --git a/android/src/main/java/com/swmansion/rnscreens/Screen.kt b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+index 04c53160789e9ef19529c532f83331859630d5f9..b8a06a6f29837379983406bd93ca921c8eb69035 100644
+--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
++++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+@@ -450,27 +450,21 @@ class Screen(
+             return
+         }
+         isBeingRemoved = false
+-        endTransitionRecursive(this)
++        endViewTransition()
+     }
+ 
+-    private fun endTransitionRecursive(parent: ViewGroup) {
+-        parent.children.forEach { childView ->
+-            parent.endViewTransition(childView)
+-
+-            if (childView is ScreenStackHeaderConfig) {
+-                endTransitionRecursive(childView.toolbar)
+-            }
+-
+-            if (childView is ViewGroup) {
+-                endTransitionRecursive(childView)
+-            }
+-        }
+-    }
++    private val transitioningViews = mutableListOf<Pair<ViewGroup, View>>()
+ 
++    /**
++     * Called when a screen gets removed. This is to mark all children as in transition,
++     * so they are not removed from the view hierarchy until endRemovalTransition is called.
++     * This is needed for the screen transition animation to work properly (otherwise the children
++     * would instantly disappear from the screen).
++     */
+     private fun startTransitionRecursive(parent: ViewGroup?) {
+-        parent?.let {
+-            for (i in 0 until it.childCount) {
+-                val child = it.getChildAt(i)
++        parent?.let { parentView ->
++            for (i in 0 until parentView.childCount) {
++                val child = parentView.getChildAt(i)
+ 
+                 if (parent is SwipeRefreshLayout && child is ImageView) {
+                     // SwipeRefreshLayout class which has CircleImageView as a child,
+@@ -479,9 +473,12 @@ class Screen(
+                     // wrong index if we called `startViewTransition` on the views on new arch.
+                     // We add a simple View to bump the number of children to make it work.
+                     // TODO: find a better way to handle this scenario
+-                    it.addView(View(context), i)
++                    parentView.addView(View(context), i)
+                 } else {
+-                    child?.let { view -> it.startViewTransition(view) }
++                    child?.let { childView ->
++                        parentView.startViewTransition(childView)
++                        transitioningViews.add(Pair(parentView, childView))
++                    }
+                 }
+ 
+                 if (child is ScreenStackHeaderConfig) {
+@@ -497,6 +494,21 @@ class Screen(
+         }
+     }
+ 
++    /**
++     * Called when the removal transition is finished. This will clear the transition state
++     * from all children and allow them to be removed from the view hierarchy and their mParent
++     * field to be set to null.
++     */
++    private fun endViewTransition() {
++        // IMPORTANT: Reverse order is needed, inner children first!
++        // Otherwise parents will call dispatchOnDetachedFromWindow on all their children,
++        // which will cause endViewTransition to have no effect on them anymore.
++        transitioningViews.asReversed().forEach { (parent, child) ->
++            parent.endViewTransition(child)
++        }
++        transitioningViews.clear()
++    }
++
+     // We do not want to perform any action, therefore do not need to override the associated method.
+     @SuppressLint("ClickableViewAccessibility")
+     override fun onTouchEvent(event: MotionEvent?): Boolean =
+diff --git a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+index bffd9c7c72f6f56e499f51d92e8ad3e597a63687..3e7e7e9028e1a55be72b8f3962162e0636f3d43c 100644
+--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
++++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+@@ -76,6 +76,10 @@ class ScreenStack(
+     }
+ 
+     override fun endViewTransition(view: View) {
++        if (view is ScreensCoordinatorLayout) {
++            view.fragment.screen.endRemovalTransition()
++        }
++
+         super.endViewTransition(view)
+ 
+         disappearingTransitioningChildren.remove(view)

--- a/src/screens/route-list/route-list-screen.tsx
+++ b/src/screens/route-list/route-list-screen.tsx
@@ -15,7 +15,7 @@ import { useShallow } from "zustand/react/shallow"
 import { useTrainRoutesStore, useRoutePlanStore, useRideStore, useSettingsStore } from "@/models"
 import { fontScale, spacing } from "@/theme"
 import type { RouteItem } from "@/services/api"
-import { Screen, RouteDetailsHeader, RouteCard, RouteCardHeight } from "@/components"
+import { Screen, RouteDetailsHeader, RouteCard } from "@/components"
 import {
   NoTrainsFoundMessage,
   RouteListError,
@@ -528,7 +528,6 @@ export function RouteListScreen() {
             paddingHorizontal: spacing[3],
             paddingBottom: shouldShowWarning ? spacing[8] + 12 : spacing[3],
           }}
-          estimatedItemSize={RouteCardHeight + spacing[3]}
           initialScrollIndex={initialScrollIndex}
           // so the list will re-render when the ride route changes, and so the item will be marked
           extraData={[rideRoute, routePlanDate, trains.status, loadingDate, hideSlowTrains]}

--- a/src/screens/select-station/select-station-screen.tsx
+++ b/src/screens/select-station/select-station-screen.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react"
 import { View, Pressable, Platform } from "react-native"
 import { StyleSheet } from "react-native-unistyles"
-import { Screen, Text, StationCard, FavoriteRoutes, cardHeight } from "@/components"
+import { Screen, Text, StationCard, FavoriteRoutes } from "@/components"
 import { useShallow } from "zustand/react/shallow"
 import { useRoutePlanStore, useRecentSearchesStore, useFavoritesStore } from "@/models"
 import { useRouter, useLocalSearchParams } from "expo-router"
@@ -65,7 +65,6 @@ export function SelectStationScreen() {
         renderItem={({ item }) => renderItem(item)}
         keyExtractor={(item) => item.id}
         keyboardShouldPersistTaps="handled"
-        estimatedItemSize={cardHeight + spacing[3]}
         ListEmptyComponent={() => (
           <View>
             <RecentSearchesBox selectionType={selectionType} />


### PR DESCRIPTION
## The issue

Some Android users hit a native crash when navigating between screens quickly — for example, rapidly selecting stations:

```
IllegalStateException: addViewAt: failed to insert view … 
The specified child already has a parent.
```

It's a bug in `react-native-screens`: when a screen transition finishes, an outgoing view can be re-inserted while it's still attached to its previous parent.

## The fix

Applies the upstream fix from react-native-screens ([#3250](https://github.com/software-mansion/react-native-screens/pull/3250), not yet released) through our existing Bun `patchedDependencies` setup — it correctly ends view transitions so recycled views are detached before reuse.

Also removes a dead `estimatedItemSize` prop from two FlashList screens (silently ignored in FlashList v2).

## Notes

- Native change — takes effect only in a fresh Android build, not via an OTA update.
- The patch is pinned to `react-native-screens@4.25.2`; a future bump will fail loudly, at which point it can be dropped once #3250 ships upstream.