### PR TITLE
chore: bump app version to v2.7.5

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -51,7 +51,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Better Rail",
   slug: "better-rail",
   owner: "better-rail",
-  version: "2.7.4",
+  version: "2.7.5",
   updates: {
     url: "https://u.expo.dev/b7819f45-8466-4c11-8628-3539099e6c78",
   },


### PR DESCRIPTION
## Summary
- Bump the Expo app version from 2.7.4 to 2.7.5 in `app.config.ts` for the next store/release build.

## Test plan
- [ ] Confirm `app.config.ts` version reads `2.7.5`
- [ ] Smoke-check that Expo config still resolves (`npx expo config --type public` or equivalent)


Made with [Cursor](https://cursor.com)