### PR TITLE
fix: prevent expo-modules-core stack overflow serializing bare Convertibles

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -104,10 +104,11 @@
     },
   },
   "patchedDependencies": {
-    "react-native-quick-actions-shortcuts@1.0.2": "patches/react-native-quick-actions-shortcuts@1.0.2.patch",
-    "react-native-screens@4.25.2": "patches/react-native-screens@4.25.2.patch",
     "react-native-watch-connectivity@1.1.0": "patches/react-native-watch-connectivity@1.1.0.patch",
+    "expo-modules-core@56.0.17": "patches/expo-modules-core@56.0.17.patch",
     "react-native-prompt-android@1.1.0": "patches/react-native-prompt-android@1.1.0.patch",
+    "react-native-screens@4.25.2": "patches/react-native-screens@4.25.2.patch",
+    "react-native-quick-actions-shortcuts@1.0.2": "patches/react-native-quick-actions-shortcuts@1.0.2.patch",
     "react-native-push-notification@8.1.1": "patches/react-native-push-notification@8.1.1.patch",
     "react-native-modal-datetime-picker@18.0.0": "patches/react-native-modal-datetime-picker@18.0.0.patch",
   },

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "react-native-watch-connectivity@1.1.0": "patches/react-native-watch-connectivity@1.1.0.patch",
     "react-native-push-notification@8.1.1": "patches/react-native-push-notification@8.1.1.patch",
     "react-native-prompt-android@1.1.0": "patches/react-native-prompt-android@1.1.0.patch",
-    "react-native-screens@4.25.2": "patches/react-native-screens@4.25.2.patch"
+    "react-native-screens@4.25.2": "patches/react-native-screens@4.25.2.patch",
+    "expo-modules-core@56.0.17": "patches/expo-modules-core@56.0.17.patch"
   }
 }

--- a/patches/expo-modules-core@56.0.17.patch
+++ b/patches/expo-modules-core@56.0.17.patch
@@ -1,0 +1,24 @@
+diff --git a/ios/Core/DynamicTypes/DynamicConvertibleType.swift b/ios/Core/DynamicTypes/DynamicConvertibleType.swift
+index 1188204ab9d08d0f60f8b0fd9b149f97861a967b..63c4a9c7d8a9ccf6f847728696e8f9ad24ad4d92 100644
+--- a/ios/Core/DynamicTypes/DynamicConvertibleType.swift
++++ b/ios/Core/DynamicTypes/DynamicConvertibleType.swift
+@@ -101,7 +101,18 @@ internal struct DynamicConvertibleType: AnyDynamicType {
+       return result
+     }
+     if let result = value as? AnyArgument {
+-      return try type(of: result).getDynamicType().castToJS(result, appContext: appContext)
++      let resultType = type(of: result).getDynamicType()
++      // Guard against infinite recursion / stack overflow: when a `Convertible` relies on the
++      // default `convertResult` (which returns the value unchanged), `convertOriginalValueToJS`
++      // hands that same value back here and its dynamic type is this exact `DynamicConvertibleType`.
++      // Re-dispatching to `castToJS` would loop forever, so serialize it generically instead.
++      if !resultType.equals(self) {
++        return try resultType.castToJS(result, appContext: appContext)
++      }
++      // Diagnostic (Better Rail / BETTER-RAIL-2Q): this is the exact value that WOULD have
++      // caused the infinite recursion. Logging its concrete Swift type identifies the module
++      // that hands a bare `Convertible` (URL/Date/CGRect/…) back to JS.
++      log.warn("DynamicConvertibleType: prevented stack-overflow serializing bare Convertible of type '\(type(of: result))' (innerType: \(innerType)) — using generic serialization instead")
+     }
+     return try Conversions.unknownToJavaScriptValue(value, appContext: appContext)
+   }


### PR DESCRIPTION
Patches `expo-modules-core@56.0.17`'s `DynamicConvertibleType` to guard against the infinite recursion / stack overflow reported in Sentry as BETTER-RAIL-2Q. When a `Convertible` relies on the default `convertResult` (which returns the value unchanged), `convertOriginalValueToJS` handed that same value back and re-dispatched to `castToJS`, looping forever. The patch now falls back to generic serialization when the resolved dynamic type is this exact type, and logs the concrete Swift type so the offending module can be identified. Registers the patch in `package.json` and `bun.lock`.