### PR TITLE
fix: prevent "new" badge from flickering on launch

### DIFF
--- a/src/screens/planner/planner-screen-header.tsx
+++ b/src/screens/planner/planner-screen-header.tsx
@@ -45,7 +45,7 @@ export function PlannerScreenHeader() {
   const router = useRouter()
   const [displayNewBadge, setDisplayNewBadge] = useState(false)
 
-  const { data: popupMessages } = useQuery(["announcements", "urgent"], () => {
+  const { data: popupMessages, isFetched: didFetchPopupMessages } = useQuery(["announcements", "urgent"], () => {
     return railApi.getPopupMessages(userLocale)
   })
 
@@ -53,6 +53,11 @@ export function PlannerScreenHeader() {
   const unseenUrgentMessages = popupMessages ? filterUnseenUrgentMessages(popupMessages, seenUrgentMessagesIds) : []
   const hasUnseenUrgentMessages = !isEmpty(unseenUrgentMessages)
   const showUrgentBar = !HIDE_URGENT_BAR && hasUnseenUrgentMessages
+
+  // Unseen urgent messages suppress the "new" badge. That answer only arrives with the popup
+  // messages response, so hold the badge back until the query settles — rendering it beforehand
+  // shows it on every launch and then yanks it away the moment the response lands.
+  const showNewBadge = displayNewBadge && didFetchPopupMessages && !hasUnseenUrgentMessages
 
   useEffect(() => {
     // display the "new" badge if the user has stations selected (not the initial launch),
@@ -109,7 +114,7 @@ export function PlannerScreenHeader() {
             </Chip>
           )}
         </View>
-        {(DEBUG_FORCE_NEW_BADGE || (displayNewBadge && !hasUnseenUrgentMessages)) && (
+        {(DEBUG_FORCE_NEW_BADGE || showNewBadge) && (
           <Chip variant="primary" style={{ marginStart: spacing[2] }} onPress={() => router.push("/live-announcement")}>
             <Image source={SPARKLES_ICON} style={{ height: 16, width: 16, marginEnd: spacing[2], tintColor: "white" }} />
             <Text style={{ color: "white", fontWeight: "500", marginVertical: spacing[1] }} tx="common.new" />


### PR DESCRIPTION
The "new" badge is suppressed when there are unseen urgent messages, but that answer only arrives with the `["announcements", "urgent"]` query — which has no cache persistence, so it refetches cold on every launch and resolves later than the local `storage.load("seenLiveAnnouncement")` read that reveals the badge. The badge therefore rendered on every launch and unmounted the moment the response landed.

This holds the badge back until the query settles, so it is never shown before we know whether it should be. Suppression behaviour is deliberately unchanged from #672 — users with unseen urgent messages still get no badge, bar or no bar. `isFetched` flips true on error as well as success, so offline users still get the badge rather than losing it permanently.

The only cost is that the badge appears a beat later, which is not noticeable in practice since `displayNewBadge` already waits on an async storage read.

Not verified on device — `node_modules` is not installed in this workspace, so neither `tsc` nor a simulator launch was run against the change.