### PR TITLE
fix: move live ride badge to the right side of the planner header

### DIFF
--- a/src/screens/planner/planner-screen-header.tsx
+++ b/src/screens/planner/planner-screen-header.tsx
@@ -95,25 +95,25 @@ export function PlannerScreenHeader() {
       <View style={styles.headerWrapper}>
         <View style={{ flex: 1, flexDirection: "row", alignItems: "center", gap: spacing[2] }}>
           {showUrgentBar && !rideRoute && <ImportantAnnouncementBar title={head(unseenUrgentMessages)?.messageBody ?? ""} />}
-
-          {rideRoute && (
-            <Chip
-              variant="success"
-              onPress={() => {
-                useNavigationParamsStore.getState().setRouteDetails({
-                  routeItem: rideRoute as any,
-                  originId: String(rideOriginId()),
-                  destinationId: String(rideDestinationId()),
-                })
-                router.push("/active-ride")
-                trackEvent("open_live_ride_modal_pressed")
-              }}
-            >
-              {Platform.OS === "ios" && <Image source={TRAIN_ICON} style={styles.liveButtonImage} />}
-              <Text style={{ color: "white", fontWeight: "500", marginVertical: spacing[1] }} tx="ride.live" />
-            </Chip>
-          )}
         </View>
+        {rideRoute && (
+          <Chip
+            variant="success"
+            style={{ marginStart: spacing[2] }}
+            onPress={() => {
+              useNavigationParamsStore.getState().setRouteDetails({
+                routeItem: rideRoute as any,
+                originId: String(rideOriginId()),
+                destinationId: String(rideDestinationId()),
+              })
+              router.push("/active-ride")
+              trackEvent("open_live_ride_modal_pressed")
+            }}
+          >
+            {Platform.OS === "ios" && <Image source={TRAIN_ICON} style={styles.liveButtonImage} />}
+            <Text style={{ color: "white", fontWeight: "500", marginVertical: spacing[1] }} tx="ride.live" />
+          </Chip>
+        )}
         {(DEBUG_FORCE_NEW_BADGE || showNewBadge) && (
           <Chip variant="primary" style={{ marginStart: spacing[2] }} onPress={() => router.push("/live-announcement")}>
             <Image source={SPARKLES_ICON} style={{ height: 16, width: 16, marginEnd: spacing[2], tintColor: "white" }} />


### PR DESCRIPTION
The live ride chip in the planner header was rendered inside the `flex: 1` container, which pinned it to the leading edge of the row. It's now rendered as a sibling after that container, so it sits at the trailing edge just before the announcements and settings icons, with the same `marginStart` spacing the "new" badge uses.

The flexible container still holds the important-announcement bar, which needs to stretch. Layout uses `flexDirection: "row"` with `marginStart`, so RTL is unaffected.

Note: not verified on a simulator — the badge only renders during an active ride.