### PR TITLE
chore: bump app version to v2.7.6

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -51,7 +51,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Better Rail",
   slug: "better-rail",
   owner: "better-rail",
-  version: "2.7.5",
+  version: "2.7.6",
   updates: {
     url: "https://u.expo.dev/b7819f45-8466-4c11-8628-3539099e6c78",
   },


### PR DESCRIPTION
Bumps `app.config.ts` version to 2.7.6 ahead of the v2.7.6 release.

Build numbers are left alone — EAS `autoIncrement` handles them.

https://claude.ai/code/session_01X6MVoXDJthYhbr34xfacB3